### PR TITLE
fix(ie): correct PFCP IE encoding issues

### DIFF
--- a/docs/architecture/binary-protocol.md
+++ b/docs/architecture/binary-protocol.md
@@ -429,14 +429,13 @@ Special compliance for F-TEID allocation (clause 8.2.3):
 ```rust
 // F-TEID with CHOOSE flag: UPF allocates IP address
 let choose_fteid = FteidBuilder::new()
-    .teid(0x12345678)
     .choose_ipv4()      // Set CHOOSE flag
     .choose_id(42)      // For correlation in response
     .build()?;
 
 // Wire format includes special flags
-// Bit 1 (CH): CHOOSE flag
-// Bit 0 (CHID): CHOOSE_ID flag
+// Bit 3 (CH): CHOOSE flag
+// Bit 4 (CHID): CHOOSE_ID flag
 ```
 
 ### Zero-Length IE Security

--- a/docs/architecture/builder-patterns.md
+++ b/docs/architecture/builder-patterns.md
@@ -224,7 +224,6 @@ let fteid = FteidBuilder::new()
 
 // CHOOSE flag - UPF selects IP
 let choose_fteid = FteidBuilder::new()
-    .teid(0x87654321)
     .choose_ipv4()
     .choose_id(42)  // For correlation
     .build()?;

--- a/docs/reference/ie-support.md
+++ b/docs/reference/ie-support.md
@@ -348,7 +348,6 @@ Also added IEs 274, 293, 294, 296, 297, 298, 299 to the `IeType` enum (previousl
 ```rust
 // 3GPP TS 29.244 compliant F-TEID with CHOOSE flags
 let f_teid = FteidBuilder::new()
-    .teid(0x12345678)
     .choose_ipv4()           // UPF chooses IPv4
     .choose_id(42)           // Correlation ID
     .build()?;

--- a/examples/session-client/main.rs
+++ b/examples/session-client/main.rs
@@ -305,7 +305,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         // Create F-TEID with CHOOSE flag (let UPF select IP)
         let choose_fteid = FteidBuilder::new()
-            .teid(0x87654321u32 + seid as u32)
             .choose_ipv4()
             .choose_id(42) // For correlation
             .build()

--- a/examples/session-server/main.rs
+++ b/examples/session-server/main.rs
@@ -137,8 +137,8 @@ fn create_quota_exhausted_usage_report() -> Option<Ie> {
 
 /// Allocate a UPF-side local F-TEID for a newly created PDR.
 ///
-/// Demonstrates three allocation strategies based on PDR ID: standard IPv4 (PDR 1),
-/// dual-stack IPv4+IPv6 (PDR 2), and CHOOSE-flag dynamic allocation (all other PDRs).
+/// Demonstrates concrete allocation strategies based on PDR ID: IPv4 (PDR 1 and other PDRs)
+/// and dual-stack IPv4+IPv6 (PDR 2).
 /// Shared by the Session Establishment and Session Modification handlers.
 fn allocate_local_fteid(pdr_id: u16) -> Result<Fteid, PfcpError> {
     let teid = 0x12345678 + pdr_id as u32;
@@ -160,11 +160,10 @@ fn allocate_local_fteid(pdr_id: u16) -> Result<Fteid, PfcpError> {
                 .build()
         }
         _ => {
-            println!("      → Using CHOOSE flag for dynamic F-TEID allocation");
+            println!("      → Allocating IPv4 F-TEID");
             FteidBuilder::new()
                 .teid(teid)
-                .choose_ipv4()
-                .choose_id(pdr_id as u8) // For correlation
+                .ipv4(Ipv4Addr::new(192, 168, 1, 100))
                 .build()
         }
     }

--- a/src/comparison/semantic.rs
+++ b/src/comparison/semantic.rs
@@ -117,6 +117,13 @@ pub fn compare_semantically_with_tolerance(
 /// different implementations might set them differently. We ignore them
 /// for semantic comparison.
 fn compare_fteid(left: &Fteid, right: &Fteid) -> SemanticMatch {
+    // Compare allocation mode before fields that are absent from CHOOSE requests.
+    if left.ch != right.ch {
+        return SemanticMatch::Mismatch {
+            details: format!("CHOOSE flag differs: {} vs {}", left.ch, right.ch),
+        };
+    }
+
     // Compare TEID
     if left.teid != right.teid {
         return SemanticMatch::Mismatch {
@@ -141,13 +148,6 @@ fn compare_fteid(left: &Fteid, right: &Fteid) -> SemanticMatch {
                 "IPv6 address differs: {:?} vs {:?}",
                 left.ipv6_address, right.ipv6_address
             ),
-        };
-    }
-
-    // Compare CHOOSE flag
-    if left.ch != right.ch {
-        return SemanticMatch::Mismatch {
-            details: format!("CHOOSE flag differs: {} vs {}", left.ch, right.ch),
         };
     }
 

--- a/src/ie/create_far.rs
+++ b/src/ie/create_far.rs
@@ -384,7 +384,7 @@ impl CreateFarBuilder {
 
     /// Creates a FAR builder for forwarding to DN (Data Network).
     pub fn to_data_network(far_id: FarId) -> Self {
-        CreateFarBuilder::new(far_id).forward_to(Interface::Dn)
+        CreateFarBuilder::new(far_id).forward_to(Interface::SgiLanN6Lan)
     }
 
     /// Creates a FAR builder with forwarding and duplication.
@@ -526,7 +526,7 @@ mod tests {
         let network_instance = NetworkInstance::new("internet");
 
         let far = CreateFarBuilder::new(far_id)
-            .forward_to_network(Interface::Dn, network_instance.clone())
+            .forward_to_network(Interface::SgiLanN6Lan, network_instance.clone())
             .build()
             .unwrap();
 
@@ -537,7 +537,7 @@ mod tests {
         let forwarding_params = far.forwarding_parameters.unwrap();
         assert_eq!(
             forwarding_params.destination_interface.interface,
-            Interface::Dn
+            Interface::SgiLanN6Lan
         );
         assert_eq!(forwarding_params.network_instance, Some(network_instance));
     }
@@ -745,7 +745,7 @@ mod tests {
         let forwarding_params = far.forwarding_parameters.unwrap();
         assert_eq!(
             forwarding_params.destination_interface.interface,
-            Interface::Dn
+            Interface::SgiLanN6Lan
         );
     }
 
@@ -791,7 +791,7 @@ mod tests {
         let network_instance = NetworkInstance::new("internet");
 
         let original = CreateFarBuilder::new(far_id)
-            .forward_to_network(Interface::Dn, network_instance.clone())
+            .forward_to_network(Interface::SgiLanN6Lan, network_instance.clone())
             .build()
             .unwrap();
 
@@ -823,7 +823,7 @@ mod tests {
 
         // Test complex builder with multiple parameters
         let far = CreateFarBuilder::new(far_id)
-            .forward_to_network(Interface::Dn, network_instance.clone())
+            .forward_to_network(Interface::SgiLanN6Lan, network_instance.clone())
             .bar_id(bar_id.clone())
             .build()
             .unwrap();
@@ -836,7 +836,7 @@ mod tests {
         let forwarding_params = far.forwarding_parameters.unwrap();
         assert_eq!(
             forwarding_params.destination_interface.interface,
-            Interface::Dn
+            Interface::SgiLanN6Lan
         );
         assert_eq!(forwarding_params.network_instance, Some(network_instance));
     }

--- a/src/ie/create_qer.rs
+++ b/src/ie/create_qer.rs
@@ -139,7 +139,7 @@ impl CreateQer {
 ///
 /// // QER with rate limits
 /// let rate_limited_qer = CreateQerBuilder::new(QerId::new(2))
-///     .mbr(Mbr::new(1000000, 2000000)) // 1Mbps up, 2Mbps down
+///     .mbr(Mbr::new(1000, 2000)) // 1 Mbit/s up, 2 Mbit/s down
 ///     .gate_status(GateStatus::new(GateStatusValue::Open, GateStatusValue::Open))
 ///     .build()
 ///     .unwrap();
@@ -193,15 +193,15 @@ impl CreateQerBuilder {
         self
     }
 
-    /// Sets both uplink and downlink rates with the same values for MBR.
-    pub fn rate_limit(mut self, uplink_bps: u64, downlink_bps: u64) -> Self {
-        self.mbr = Some(Mbr::new(uplink_bps, downlink_bps));
+    /// Sets both uplink and downlink MBR values in kbit/s.
+    pub fn rate_limit(mut self, uplink_kbps: u64, downlink_kbps: u64) -> Self {
+        self.mbr = Some(Mbr::new(uplink_kbps, downlink_kbps));
         self
     }
 
-    /// Sets guaranteed bit rates for both directions.
-    pub fn guaranteed_rate(mut self, uplink_bps: u64, downlink_bps: u64) -> Self {
-        self.gbr = Some(Gbr::new(uplink_bps, downlink_bps));
+    /// Sets both uplink and downlink GBR values in kbit/s.
+    pub fn guaranteed_rate(mut self, uplink_kbps: u64, downlink_kbps: u64) -> Self {
+        self.gbr = Some(Gbr::new(uplink_kbps, downlink_kbps));
         self
     }
 
@@ -279,9 +279,9 @@ impl CreateQerBuilder {
         ))
     }
 
-    /// Creates a QER builder with rate limiting for both directions.
-    pub fn with_rate_limit(qer_id: QerId, uplink_bps: u64, downlink_bps: u64) -> Self {
-        CreateQerBuilder::open_gate(qer_id).rate_limit(uplink_bps, downlink_bps)
+    /// Creates a QER builder with rate limiting in kbit/s for both directions.
+    pub fn with_rate_limit(qer_id: QerId, uplink_kbps: u64, downlink_kbps: u64) -> Self {
+        CreateQerBuilder::open_gate(qer_id).rate_limit(uplink_kbps, downlink_kbps)
     }
 }
 
@@ -305,9 +305,9 @@ impl CreateQer {
             .expect("Closed gate QER construction should not fail")
     }
 
-    /// Creates a QER with rate limiting.
-    pub fn with_rate_limit(qer_id: QerId, uplink_bps: u64, downlink_bps: u64) -> Self {
-        CreateQerBuilder::with_rate_limit(qer_id, uplink_bps, downlink_bps)
+    /// Creates a QER with rate limiting in kbit/s.
+    pub fn with_rate_limit(qer_id: QerId, uplink_kbps: u64, downlink_kbps: u64) -> Self {
+        CreateQerBuilder::with_rate_limit(qer_id, uplink_kbps, downlink_kbps)
             .build()
             .expect("Rate limited QER construction should not fail")
     }
@@ -361,8 +361,8 @@ mod tests {
         let qer_id = QerId::new(100);
         let qer_correlation_id = QerCorrelationId::new(0x12345678);
         let gate_status = GateStatus::new(GateStatusValue::Open, GateStatusValue::Closed);
-        let mbr = Mbr::new(1000000, 2000000);
-        let gbr = Gbr::new(500000, 1000000);
+        let mbr = Mbr::new(1_000, 2_000);
+        let gbr = Gbr::new(500, 1_000);
 
         let qer = CreateQer {
             qer_id,
@@ -449,30 +449,30 @@ mod tests {
     fn test_builder_rate_limit() {
         let qer_id = QerId::new(1);
         let qer = CreateQerBuilder::new(qer_id)
-            .rate_limit(1000000, 2000000)
+            .rate_limit(1_000, 2_000)
             .build()
             .expect("Failed to build Create QER with rate limit");
 
         assert_eq!(qer.qer_id, qer_id);
         assert!(qer.mbr.is_some());
         let mbr = qer.mbr.expect("MBR should be set by rate_limit()");
-        assert_eq!(mbr.uplink, 1000000);
-        assert_eq!(mbr.downlink, 2000000);
+        assert_eq!(mbr.uplink, 1000);
+        assert_eq!(mbr.downlink, 2000);
     }
 
     #[test]
     fn test_builder_guaranteed_rate() {
         let qer_id = QerId::new(1);
         let qer = CreateQerBuilder::new(qer_id)
-            .guaranteed_rate(500000, 1000000)
+            .guaranteed_rate(500, 1_000)
             .build()
             .unwrap();
 
         assert_eq!(qer.qer_id, qer_id);
         assert!(qer.gbr.is_some());
         let gbr = qer.gbr.unwrap();
-        assert_eq!(gbr.uplink, 500000);
-        assert_eq!(gbr.downlink, 1000000);
+        assert_eq!(gbr.uplink, 500);
+        assert_eq!(gbr.downlink, 1000);
     }
 
     #[test]
@@ -534,7 +534,7 @@ mod tests {
     #[test]
     fn test_builder_with_rate_limit() {
         let qer_id = QerId::new(1);
-        let qer = CreateQerBuilder::with_rate_limit(qer_id, 1000000, 2000000)
+        let qer = CreateQerBuilder::with_rate_limit(qer_id, 1_000, 2_000)
             .build()
             .unwrap();
 
@@ -547,8 +547,8 @@ mod tests {
         assert_eq!(gate_status.downlink_gate, GateStatusValue::Open);
 
         let mbr = qer.mbr.unwrap();
-        assert_eq!(mbr.uplink, 1000000);
-        assert_eq!(mbr.downlink, 2000000);
+        assert_eq!(mbr.uplink, 1000);
+        assert_eq!(mbr.downlink, 2000);
     }
 
     #[test]
@@ -560,8 +560,8 @@ mod tests {
                 GateStatusValue::Closed,
                 GateStatusValue::Open,
             ))
-            .rate_limit(500000, 1500000)
-            .guaranteed_rate(250000, 750000)
+            .rate_limit(500, 1_500)
+            .guaranteed_rate(250, 750)
             .build()
             .unwrap();
 
@@ -574,8 +574,8 @@ mod tests {
     #[test]
     fn test_builder_ie_round_trip() {
         let qer_id = QerId::new(99);
-        let original = CreateQerBuilder::with_rate_limit(qer_id, 2000000, 4000000)
-            .guaranteed_rate(1000000, 2000000)
+        let original = CreateQerBuilder::with_rate_limit(qer_id, 2_000, 4_000)
+            .guaranteed_rate(1_000, 2_000)
             .build()
             .unwrap();
 
@@ -614,15 +614,15 @@ mod tests {
     #[test]
     fn test_convenience_with_rate_limit() {
         let qer_id = QerId::new(1);
-        let qer = CreateQer::with_rate_limit(qer_id, 3000000, 6000000);
+        let qer = CreateQer::with_rate_limit(qer_id, 3_000, 6_000);
 
         assert_eq!(qer.qer_id, qer_id);
         assert!(qer.gate_status.is_some());
         assert!(qer.mbr.is_some());
 
         let mbr = qer.mbr.unwrap();
-        assert_eq!(mbr.uplink, 3000000);
-        assert_eq!(mbr.downlink, 6000000);
+        assert_eq!(mbr.uplink, 3000);
+        assert_eq!(mbr.downlink, 6000);
     }
 
     #[test]

--- a/src/ie/created_pdr.rs
+++ b/src/ie/created_pdr.rs
@@ -115,7 +115,7 @@ mod tests {
             true,  // v4
             false, // v6
             false, // ch
-            true,  // chid
+            false, // chid
             0x87654321,
             Some(Ipv4Addr::new(10, 0, 0, 1)),
             None,
@@ -129,7 +129,7 @@ mod tests {
         assert_eq!(created_pdr, unmarshaled);
         assert_eq!(unmarshaled.pdr_id.value, 100);
         assert_eq!(unmarshaled.f_teid.teid, Teid(0x87654321));
-        assert_eq!(unmarshaled.f_teid.choose_id, 200);
-        assert!(unmarshaled.f_teid.chid);
+        assert_eq!(unmarshaled.f_teid.choose_id, 0);
+        assert!(!unmarshaled.f_teid.chid);
     }
 }

--- a/src/ie/destination_interface.rs
+++ b/src/ie/destination_interface.rs
@@ -5,90 +5,39 @@ use crate::ie::{Ie, IeType};
 
 /// Represents the possible values for a Destination Interface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum Interface {
-    Access,
-    Core,
-    Smf,
-    Amf,
-    Dn,
-    Lcs,
-    ScScf,
-    InterSystem,
-    Iu,
-    S1,
-    S11,
-    S12,
-    S1U,
-    S2a,
-    S2b,
-    S4,
-    S5S8,
-    S6a,
-    SGi,
-    Sm,
-    Sn,
-    Szn,
-    X2,
+    Access = 0,
+    Core = 1,
+    SgiLanN6Lan = 2,
+    CpFunction = 3,
+    LiFunction = 4,
+    FiveGvnInternal = 5,
 }
 
-impl From<u8> for Interface {
-    fn from(v: u8) -> Self {
-        match v {
-            0 => Interface::Access,
-            1 => Interface::Core,
-            2 => Interface::Smf,
-            3 => Interface::Amf,
-            4 => Interface::Dn,
-            5 => Interface::Lcs,
-            6 => Interface::ScScf,
-            7 => Interface::InterSystem,
-            10 => Interface::Iu,
-            11 => Interface::S1,
-            12 => Interface::S11,
-            13 => Interface::S12,
-            14 => Interface::S1U,
-            15 => Interface::S2a,
-            16 => Interface::S2b,
-            17 => Interface::S4,
-            18 => Interface::S5S8,
-            19 => Interface::S6a,
-            20 => Interface::SGi,
-            21 => Interface::Sm,
-            22 => Interface::Sn,
-            23 => Interface::Szn,
-            24 => Interface::X2,
-            _ => Interface::Access, // Default or unknown
+impl TryFrom<u8> for Interface {
+    type Error = PfcpError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value & 0x0f {
+            0 => Ok(Interface::Access),
+            1 => Ok(Interface::Core),
+            2 => Ok(Interface::SgiLanN6Lan),
+            3 => Ok(Interface::CpFunction),
+            4 => Ok(Interface::LiFunction),
+            5 => Ok(Interface::FiveGvnInternal),
+            value => Err(PfcpError::invalid_value(
+                "Destination Interface",
+                value.to_string(),
+                "must be 0-5",
+            )),
         }
     }
 }
 
 impl From<Interface> for u8 {
     fn from(i: Interface) -> Self {
-        match i {
-            Interface::Access => 0,
-            Interface::Core => 1,
-            Interface::Smf => 2,
-            Interface::Amf => 3,
-            Interface::Dn => 4,
-            Interface::Lcs => 5,
-            Interface::ScScf => 6,
-            Interface::InterSystem => 7,
-            Interface::Iu => 10,
-            Interface::S1 => 11,
-            Interface::S11 => 12,
-            Interface::S12 => 13,
-            Interface::S1U => 14,
-            Interface::S2a => 15,
-            Interface::S2b => 16,
-            Interface::S4 => 17,
-            Interface::S5S8 => 18,
-            Interface::S6a => 19,
-            Interface::SGi => 20,
-            Interface::Sm => 21,
-            Interface::Sn => 22,
-            Interface::Szn => 23,
-            Interface::X2 => 24,
-        }
+        i as u8
     }
 }
 
@@ -122,7 +71,7 @@ impl DestinationInterface {
             ));
         }
         Ok(DestinationInterface {
-            interface: payload[0].into(),
+            interface: Interface::try_from(payload[0])?,
         })
     }
 
@@ -153,5 +102,35 @@ mod tests {
         assert!(err.to_string().contains("Destination Interface"));
         assert!(err.to_string().contains("1"));
         assert!(err.to_string().contains("0"));
+    }
+
+    #[test]
+    fn test_destination_interface_current_values() {
+        let values = [
+            Interface::Access,
+            Interface::Core,
+            Interface::SgiLanN6Lan,
+            Interface::CpFunction,
+            Interface::LiFunction,
+            Interface::FiveGvnInternal,
+        ];
+
+        for (wire, interface) in values.into_iter().enumerate() {
+            assert_eq!(DestinationInterface::new(interface).marshal(), [wire as u8]);
+            assert_eq!(
+                DestinationInterface::unmarshal(&[wire as u8])
+                    .unwrap()
+                    .interface,
+                interface
+            );
+        }
+    }
+
+    #[test]
+    fn test_destination_interface_rejects_unknown_value() {
+        assert!(matches!(
+            DestinationInterface::unmarshal(&[6]),
+            Err(PfcpError::InvalidValue { .. })
+        ));
     }
 }

--- a/src/ie/f_teid.rs
+++ b/src/ie/f_teid.rs
@@ -26,7 +26,7 @@ impl Fteid {
         teid: impl Into<Teid>,
         ipv4_address: Option<Ipv4Addr>,
         ipv6_address: Option<Ipv6Addr>,
-        choose_id: u8,
+        _choose_id: u8,
     ) -> Self {
         Fteid {
             v4,
@@ -36,7 +36,7 @@ impl Fteid {
             teid: teid.into(),
             ipv4_address,
             ipv6_address,
-            choose_id,
+            choose_id: 0,
         }
     }
 
@@ -54,15 +54,16 @@ impl Fteid {
         ipv6_address: Option<Ipv6Addr>,
         choose_id: u8,
     ) -> Self {
+        let teid = if ch { Teid::default() } else { teid.into() };
         Fteid {
             v4,
             v6,
             ch,
-            chid,
-            teid: teid.into(),
-            ipv4_address,
-            ipv6_address,
-            choose_id,
+            chid: ch && chid,
+            teid,
+            ipv4_address: if ch { None } else { ipv4_address },
+            ipv6_address: if ch { None } else { ipv6_address },
+            choose_id: if ch && chid { choose_id } else { 0 },
         }
     }
 
@@ -79,10 +80,16 @@ impl Fteid {
         if self.ch {
             flags |= 0x04; // CH flag (bit 2)
         }
-        if self.chid {
+        if self.ch && self.chid {
             flags |= 0x08; // CHID flag (bit 3)
         }
         data.push(flags);
+        if self.ch {
+            if self.chid {
+                data.push(self.choose_id);
+            }
+            return data;
+        }
         data.extend_from_slice(&self.teid.0.to_be_bytes());
         if let Some(addr) = self.ipv4_address {
             data.extend_from_slice(&addr.octets());
@@ -90,22 +97,19 @@ impl Fteid {
         if let Some(addr) = self.ipv6_address {
             data.extend_from_slice(&addr.octets());
         }
-        // Only include choose_id if CHID flag is set
-        if self.chid {
-            data.push(self.choose_id);
-        }
         data
     }
 
     /// Unmarshals a byte slice into an F-TEID.
     ///
-    /// Per 3GPP TS 29.244, F-TEID requires minimum 5 bytes (1 byte flags + 4 bytes TEID).
+    /// A CHOOSE request contains only the flags octet and an optional Choose ID. A concrete
+    /// F-TEID contains the flags, TEID, and the selected IP addresses.
     pub fn unmarshal(payload: &[u8]) -> Result<Self, PfcpError> {
-        if payload.len() < 5 {
+        if payload.is_empty() {
             return Err(PfcpError::invalid_length(
                 "F-TEID",
                 IeType::Fteid,
-                5,
+                1,
                 payload.len(),
             ));
         }
@@ -114,10 +118,43 @@ impl Fteid {
         let v6 = flags & 0x02 != 0;
         let ch = flags & 0x04 != 0;
         let chid = flags & 0x08 != 0;
+        if ch {
+            let choose_id = if chid {
+                *payload.get(1).ok_or_else(|| {
+                    PfcpError::invalid_length("F-TEID choose ID", IeType::Fteid, 2, payload.len())
+                })?
+            } else {
+                0
+            };
+            return Ok(Fteid {
+                v4,
+                v6,
+                ch,
+                chid,
+                teid: Teid::default(),
+                ipv4_address: None,
+                ipv6_address: None,
+                choose_id,
+            });
+        }
+        if chid {
+            return Err(PfcpError::invalid_value(
+                "F-TEID choose ID",
+                format!("flags 0x{flags:02x}"),
+                "CHID requires the CH flag",
+            ));
+        }
+        if payload.len() < 5 {
+            return Err(PfcpError::invalid_length(
+                "F-TEID",
+                IeType::Fteid,
+                5,
+                payload.len(),
+            ));
+        }
         let teid = u32::from_be_bytes([payload[1], payload[2], payload[3], payload[4]]);
         let mut offset = 5;
-        let ipv4_address = if v4 && !ch {
-            // IPv4 address is present only if V4 flag is set and CHOOSE flag is NOT set
+        let ipv4_address = if v4 {
             if payload.len() < offset + 4 {
                 return Err(PfcpError::invalid_length(
                     "F-TEID IPv4",
@@ -134,27 +171,10 @@ impl Fteid {
             );
             offset += 4;
             Some(addr)
-        } else if v4 && ch {
-            // V4 flag set with CHOOSE flag - check if address is present
-            if payload.len() >= offset + 4 {
-                // Address is present (optional with CHOOSE)
-                let addr = Ipv4Addr::new(
-                    payload[offset],
-                    payload[offset + 1],
-                    payload[offset + 2],
-                    payload[offset + 3],
-                );
-                offset += 4;
-                Some(addr)
-            } else {
-                // No address present with CHOOSE flag
-                None
-            }
         } else {
             None
         };
-        let ipv6_address = if v6 && !ch {
-            // IPv6 address is present only if V6 flag is set and CHOOSE flag is NOT set
+        let ipv6_address = if v6 {
             if payload.len() < offset + 16 {
                 return Err(PfcpError::invalid_length(
                     "F-TEID IPv6",
@@ -165,36 +185,9 @@ impl Fteid {
             }
             let mut octets = [0; 16];
             octets.copy_from_slice(&payload[offset..offset + 16]);
-            offset += 16;
             Some(Ipv6Addr::from(octets))
-        } else if v6 && ch {
-            // V6 flag set with CHOOSE flag - check if address is present
-            if payload.len() >= offset + 16 {
-                // Address is present (optional with CHOOSE)
-                let mut octets = [0; 16];
-                octets.copy_from_slice(&payload[offset..offset + 16]);
-                offset += 16;
-                Some(Ipv6Addr::from(octets))
-            } else {
-                // No address present with CHOOSE flag
-                None
-            }
         } else {
             None
-        };
-        // Only read choose_id if CHID flag is set
-        let choose_id = if chid {
-            if payload.len() < offset + 1 {
-                return Err(PfcpError::invalid_length(
-                    "F-TEID choose ID",
-                    IeType::Fteid,
-                    offset + 1,
-                    payload.len(),
-                ));
-            }
-            payload[offset]
-        } else {
-            0
         };
         Ok(Fteid {
             v4,
@@ -204,7 +197,7 @@ impl Fteid {
             teid: Teid(teid),
             ipv4_address,
             ipv6_address,
-            choose_id,
+            choose_id: 0,
         })
     }
 
@@ -235,14 +228,12 @@ impl Fteid {
 ///
 /// // F-TEID with CHOOSE flag (UPF selects IP)
 /// let choose_fteid = FteidBuilder::new()
-///     .teid(0x87654321)
 ///     .choose_ipv4()
 ///     .build()
 ///     .unwrap();
 ///
 /// // F-TEID with CHOOSE ID for correlation
 /// let choose_id_fteid = FteidBuilder::new()
-///     .teid(0xABCDEF00)
 ///     .choose_ipv4()
 ///     .choose_id(42)
 ///     .build()
@@ -266,7 +257,7 @@ impl FteidBuilder {
 
     /// Sets the TEID (Tunnel Endpoint Identifier).
     ///
-    /// This is a required field for all F-TEID instances.
+    /// This is required for a concrete F-TEID and omitted from CHOOSE requests.
     pub fn teid(mut self, teid: impl Into<Teid>) -> Self {
         self.teid = Some(teid.into());
         self
@@ -332,17 +323,11 @@ impl FteidBuilder {
     /// # Errors
     ///
     /// Returns an error if:
-    /// - TEID is not set
+    /// - TEID is not set for a concrete (non-CHOOSE) F-TEID
     /// - No IP addressing method is specified (neither explicit addresses nor CHOOSE flags)
     /// - Both explicit address and CHOOSE flag are set for the same IP version
     /// - CHOOSE ID is set but no CHOOSE flags are enabled
     pub fn build(self) -> Result<Fteid, PfcpError> {
-        let teid = self.teid.ok_or(PfcpError::validation_error(
-            "FteidBuilder",
-            "teid",
-            "TEID is required",
-        ))?;
-
         // Validate IPv4 configuration
         if self.ipv4_address.is_some() && self.choose_ipv4 {
             return Err(PfcpError::validation_error(
@@ -388,6 +373,15 @@ impl FteidBuilder {
         let ch = self.choose_ipv4 || self.choose_ipv6;
         let chid = self.choose_id.is_some();
         let choose_id = self.choose_id.unwrap_or(0);
+        let teid = if ch {
+            Teid::default()
+        } else {
+            self.teid.ok_or(PfcpError::validation_error(
+                "FteidBuilder",
+                "teid",
+                "TEID is required",
+            ))?
+        };
 
         Ok(Fteid {
             v4,
@@ -436,27 +430,31 @@ impl Fteid {
     }
 
     /// Creates an F-TEID with CHOOSE IPv4 flag.
-    pub fn choose_ipv4(teid: impl Into<Teid>) -> Self {
+    ///
+    /// The TEID argument is retained for API compatibility but is not encoded: CHOOSE requests
+    /// require the UP function to allocate the TEID.
+    pub fn choose_ipv4(_teid: impl Into<Teid>) -> Self {
         FteidBuilder::new()
-            .teid(teid)
             .choose_ipv4()
             .build()
             .expect("CHOOSE IPv4 F-TEID construction should not fail")
     }
 
     /// Creates an F-TEID with CHOOSE IPv6 flag.
-    pub fn choose_ipv6(teid: impl Into<Teid>) -> Self {
+    ///
+    /// The TEID argument is retained for API compatibility but is not encoded.
+    pub fn choose_ipv6(_teid: impl Into<Teid>) -> Self {
         FteidBuilder::new()
-            .teid(teid)
             .choose_ipv6()
             .build()
             .expect("CHOOSE IPv6 F-TEID construction should not fail")
     }
 
     /// Creates an F-TEID with CHOOSE flags for both IPv4 and IPv6.
-    pub fn choose_dual_stack(teid: impl Into<Teid>) -> Self {
+    ///
+    /// The TEID argument is retained for API compatibility but is not encoded.
+    pub fn choose_dual_stack(_teid: impl Into<Teid>) -> Self {
         FteidBuilder::new()
-            .teid(teid)
             .choose_dual_stack()
             .build()
             .expect("CHOOSE dual-stack F-TEID construction should not fail")
@@ -548,8 +546,8 @@ mod tests {
         assert!(unmarshaled.ch);
         assert!(!unmarshaled.chid);
 
-        // Verify marshaled data doesn't include choose_id when chid=false
-        assert_eq!(marshaled.len(), 9); // flags(1) + teid(4) + ipv4(4) = 9 bytes
+        // CHOOSE omits the TEID and IP address fields.
+        assert_eq!(marshaled, [0x05]);
     }
 
     #[test]
@@ -557,8 +555,8 @@ mod tests {
         let fteid = Fteid::new_with_choose(
             true,
             false,
-            false, // ch = false
-            true,  // chid = true
+            true, // ch = true
+            true, // chid = true
             0x12345678,
             Some(Ipv4Addr::new(192, 168, 0, 1)),
             None,
@@ -567,13 +565,12 @@ mod tests {
         let marshaled = fteid.marshal();
         let unmarshaled = Fteid::unmarshal(&marshaled).unwrap();
         assert_eq!(unmarshaled, fteid);
-        assert!(!unmarshaled.ch);
+        assert!(unmarshaled.ch);
         assert!(unmarshaled.chid);
         assert_eq!(unmarshaled.choose_id, 42);
 
         // Verify marshaled data includes choose_id when chid=true
-        assert_eq!(marshaled.len(), 10); // flags(1) + teid(4) + ipv4(4) + choose_id(1) = 10 bytes
-        assert_eq!(marshaled[9], 42); // Last byte should be choose_id
+        assert_eq!(marshaled, [0x0d, 42]);
     }
 
     #[test]
@@ -708,17 +705,13 @@ mod tests {
 
     #[test]
     fn test_fteid_builder_choose_ipv4() {
-        let fteid = FteidBuilder::new()
-            .teid(0x11111111)
-            .choose_ipv4()
-            .build()
-            .unwrap();
+        let fteid = FteidBuilder::new().choose_ipv4().build().unwrap();
 
         assert!(fteid.v4);
         assert!(!fteid.v6);
         assert!(fteid.ch);
         assert!(!fteid.chid);
-        assert_eq!(fteid.teid, Teid(0x11111111));
+        assert_eq!(fteid.teid, Teid(0));
         assert_eq!(fteid.ipv4_address, None);
         assert_eq!(fteid.ipv6_address, None);
         assert_eq!(fteid.choose_id, 0);
@@ -731,17 +724,13 @@ mod tests {
 
     #[test]
     fn test_fteid_builder_choose_ipv6() {
-        let fteid = FteidBuilder::new()
-            .teid(0x22222222)
-            .choose_ipv6()
-            .build()
-            .unwrap();
+        let fteid = FteidBuilder::new().choose_ipv6().build().unwrap();
 
         assert!(!fteid.v4);
         assert!(fteid.v6);
         assert!(fteid.ch);
         assert!(!fteid.chid);
-        assert_eq!(fteid.teid, Teid(0x22222222));
+        assert_eq!(fteid.teid, Teid(0));
         assert_eq!(fteid.ipv4_address, None);
         assert_eq!(fteid.ipv6_address, None);
         assert_eq!(fteid.choose_id, 0);
@@ -754,17 +743,13 @@ mod tests {
 
     #[test]
     fn test_fteid_builder_choose_dual_stack() {
-        let fteid = FteidBuilder::new()
-            .teid(0x33333333)
-            .choose_dual_stack()
-            .build()
-            .unwrap();
+        let fteid = FteidBuilder::new().choose_dual_stack().build().unwrap();
 
         assert!(fteid.v4);
         assert!(fteid.v6);
         assert!(fteid.ch);
         assert!(!fteid.chid);
-        assert_eq!(fteid.teid, Teid(0x33333333));
+        assert_eq!(fteid.teid, Teid(0));
         assert_eq!(fteid.ipv4_address, None);
         assert_eq!(fteid.ipv6_address, None);
         assert_eq!(fteid.choose_id, 0);
@@ -778,7 +763,6 @@ mod tests {
     #[test]
     fn test_fteid_builder_choose_with_id() {
         let fteid = FteidBuilder::new()
-            .teid(0x44444444)
             .choose_ipv4()
             .choose_id(42)
             .build()
@@ -788,7 +772,7 @@ mod tests {
         assert!(!fteid.v6);
         assert!(fteid.ch);
         assert!(fteid.chid);
-        assert_eq!(fteid.teid, Teid(0x44444444));
+        assert_eq!(fteid.teid, Teid(0));
         assert_eq!(fteid.ipv4_address, None);
         assert_eq!(fteid.ipv6_address, None);
         assert_eq!(fteid.choose_id, 42);
@@ -802,7 +786,6 @@ mod tests {
     #[test]
     fn test_fteid_builder_choose_dual_stack_with_id() {
         let fteid = FteidBuilder::new()
-            .teid(0x55555555)
             .choose_dual_stack()
             .choose_id(100)
             .build()
@@ -812,7 +795,7 @@ mod tests {
         assert!(fteid.v6);
         assert!(fteid.ch);
         assert!(fteid.chid);
-        assert_eq!(fteid.teid, Teid(0x55555555));
+        assert_eq!(fteid.teid, Teid(0));
         assert_eq!(fteid.ipv4_address, None);
         assert_eq!(fteid.ipv6_address, None);
         assert_eq!(fteid.choose_id, 100);
@@ -944,7 +927,7 @@ mod tests {
         assert!(!fteid.v6);
         assert!(fteid.ch);
         assert!(!fteid.chid);
-        assert_eq!(fteid.teid, Teid(0x11111111));
+        assert_eq!(fteid.teid, Teid(0));
         assert_eq!(fteid.ipv4_address, None);
         assert_eq!(fteid.ipv6_address, None);
     }
@@ -957,7 +940,7 @@ mod tests {
         assert!(fteid.v6);
         assert!(fteid.ch);
         assert!(!fteid.chid);
-        assert_eq!(fteid.teid, Teid(0x22222222));
+        assert_eq!(fteid.teid, Teid(0));
         assert_eq!(fteid.ipv4_address, None);
         assert_eq!(fteid.ipv6_address, None);
     }
@@ -970,7 +953,7 @@ mod tests {
         assert!(fteid.v6);
         assert!(fteid.ch);
         assert!(!fteid.chid);
-        assert_eq!(fteid.teid, Teid(0x33333333));
+        assert_eq!(fteid.teid, Teid(0));
         assert_eq!(fteid.ipv4_address, None);
         assert_eq!(fteid.ipv6_address, None);
     }
@@ -1000,7 +983,19 @@ mod tests {
         assert!(fteid.v6);
         assert!(fteid.ch);
         assert!(fteid.chid);
-        assert_eq!(fteid.teid, Teid(0xDEADBEEF));
+        assert_eq!(fteid.teid, Teid(0));
         assert_eq!(fteid.choose_id, 50);
+    }
+
+    #[test]
+    fn test_fteid_builder_choose_does_not_require_teid() {
+        let fteid = FteidBuilder::new()
+            .choose_ipv4()
+            .choose_id(42)
+            .build()
+            .unwrap();
+
+        assert_eq!(fteid.marshal(), [0x0d, 42]);
+        assert_eq!(Fteid::unmarshal(&[0x0d, 42]).unwrap(), fteid);
     }
 }

--- a/src/ie/gbr.rs
+++ b/src/ie/gbr.rs
@@ -7,13 +7,19 @@ use crate::ie::IeType;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Gbr {
+    /// Uplink guaranteed bitrate in the PFCP wire unit of kbit/s.
     pub uplink: u64,
+    /// Downlink guaranteed bitrate in the PFCP wire unit of kbit/s.
     pub downlink: u64,
 }
 
 impl Gbr {
-    pub fn new(uplink: u64, downlink: u64) -> Self {
-        Gbr { uplink, downlink }
+    /// Creates a GBR using the PFCP wire unit of kbit/s.
+    pub const fn new(uplink_kbps: u64, downlink_kbps: u64) -> Self {
+        Gbr {
+            uplink: uplink_kbps,
+            downlink: downlink_kbps,
+        }
     }
 
     pub fn marshal(&self) -> [u8; 10] {
@@ -49,7 +55,7 @@ mod tests {
 
     #[test]
     fn test_gbr_marshal_unmarshal() {
-        let gbr = Gbr::new(500_000, 750_000);
+        let gbr = Gbr::new(500, 750);
         let marshaled = gbr.marshal();
         let unmarshaled = Gbr::unmarshal(&marshaled).unwrap();
         assert_eq!(unmarshaled, gbr);

--- a/src/ie/mbr.rs
+++ b/src/ie/mbr.rs
@@ -7,13 +7,19 @@ use crate::ie::IeType;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Mbr {
+    /// Uplink maximum bitrate in the PFCP wire unit of kbit/s.
     pub uplink: u64,
+    /// Downlink maximum bitrate in the PFCP wire unit of kbit/s.
     pub downlink: u64,
 }
 
 impl Mbr {
-    pub fn new(uplink: u64, downlink: u64) -> Self {
-        Mbr { uplink, downlink }
+    /// Creates an MBR using the PFCP wire unit of kbit/s.
+    pub const fn new(uplink_kbps: u64, downlink_kbps: u64) -> Self {
+        Mbr {
+            uplink: uplink_kbps,
+            downlink: downlink_kbps,
+        }
     }
 
     pub fn marshal(&self) -> [u8; 10] {
@@ -49,7 +55,7 @@ mod tests {
 
     #[test]
     fn test_mbr_marshal_unmarshal() {
-        let mbr = Mbr::new(1_000_000, 2_000_000);
+        let mbr = Mbr::new(1_000, 2_000);
         let marshaled = mbr.marshal();
         let unmarshaled = Mbr::unmarshal(&marshaled).unwrap();
         assert_eq!(unmarshaled, mbr);

--- a/src/ie/pdi.rs
+++ b/src/ie/pdi.rs
@@ -6,7 +6,8 @@ use crate::error::PfcpError;
 use crate::ie::{
     ethernet_packet_filter::EthernetPacketFilter, f_teid::Fteid, marshal_ies,
     network_instance::NetworkInstance, sdf_filter::SdfFilter, source_interface::SourceInterface,
-    ue_ip_address::UeIpAddress, Ie, IeIterator, IeType,
+    three_gpp_interface_type::ThreeGppInterfaceTypeIe, ue_ip_address::UeIpAddress, Ie, IeIterator,
+    IeType,
 };
 
 /// Represents the Packet Detection Information.
@@ -19,6 +20,7 @@ pub struct Pdi {
     pub sdf_filter: Option<SdfFilter>,
     pub application_id: Option<String>,
     pub ethernet_packet_filter: Option<EthernetPacketFilter>,
+    pub three_gpp_interface_type: Option<ThreeGppInterfaceTypeIe>,
     pub redundant_transmission_parameters: Option<Ie>,
     /// Protocol description for PDU-set/EDB marking (IE 334, optional).
     pub protocol_description: Option<Ie>,
@@ -43,6 +45,7 @@ impl Pdi {
             sdf_filter,
             application_id,
             ethernet_packet_filter,
+            three_gpp_interface_type: None,
             redundant_transmission_parameters: None,
             protocol_description: None,
         }
@@ -70,6 +73,9 @@ impl Pdi {
         if let Some(eth_filter) = &self.ethernet_packet_filter {
             ies.push(eth_filter.to_ie());
         }
+        if let Some(interface_type) = &self.three_gpp_interface_type {
+            ies.push(interface_type.to_ie());
+        }
         if let Some(ref rtp) = self.redundant_transmission_parameters {
             ies.push(rtp.clone());
         }
@@ -89,6 +95,7 @@ impl Pdi {
         let mut sdf_filter = None;
         let mut application_id = None;
         let mut ethernet_packet_filter = None;
+        let mut three_gpp_interface_type = None;
         let mut redundant_transmission_parameters = None;
         let mut protocol_description = None;
 
@@ -116,6 +123,10 @@ impl Pdi {
                 IeType::EthernetPacketFilter => {
                     ethernet_packet_filter = Some(EthernetPacketFilter::unmarshal(&ie.payload)?);
                 }
+                IeType::TgppInterfaceType => {
+                    three_gpp_interface_type =
+                        Some(ThreeGppInterfaceTypeIe::unmarshal(&ie.payload)?);
+                }
                 IeType::RedundantTransmissionParameters => {
                     redundant_transmission_parameters = Some(ie);
                 }
@@ -137,6 +148,7 @@ impl Pdi {
             sdf_filter,
             application_id,
             ethernet_packet_filter,
+            three_gpp_interface_type,
             redundant_transmission_parameters,
             protocol_description,
         })
@@ -191,6 +203,7 @@ pub struct PdiBuilder {
     sdf_filter: Option<SdfFilter>,
     application_id: Option<String>,
     ethernet_packet_filter: Option<EthernetPacketFilter>,
+    three_gpp_interface_type: Option<ThreeGppInterfaceTypeIe>,
     redundant_transmission_parameters: Option<Ie>,
     protocol_description: Option<Ie>,
 }
@@ -255,6 +268,12 @@ impl PdiBuilder {
         self
     }
 
+    /// Sets the 3GPP Interface Type associated with this PDI.
+    pub fn three_gpp_interface_type(mut self, interface_type: ThreeGppInterfaceTypeIe) -> Self {
+        self.three_gpp_interface_type = Some(interface_type);
+        self
+    }
+
     /// Builds the PDI with validation.
     ///
     /// # Errors
@@ -275,6 +294,7 @@ impl PdiBuilder {
             sdf_filter: self.sdf_filter,
             application_id: self.application_id,
             ethernet_packet_filter: self.ethernet_packet_filter,
+            three_gpp_interface_type: self.three_gpp_interface_type,
             redundant_transmission_parameters: self.redundant_transmission_parameters,
             protocol_description: self.protocol_description,
         })
@@ -371,6 +391,7 @@ mod tests {
     use crate::ie::network_instance::NetworkInstance;
     use crate::ie::sdf_filter::SdfFilter;
     use crate::ie::source_interface::{SourceInterface, SourceInterfaceValue};
+    use crate::ie::three_gpp_interface_type::{ThreeGppInterfaceType, ThreeGppInterfaceTypeIe};
     use crate::ie::ue_ip_address::UeIpAddress;
     use std::net::Ipv4Addr;
 
@@ -440,6 +461,18 @@ mod tests {
         let marshaled = pdi.marshal();
         let unmarshaled = Pdi::unmarshal(&marshaled).unwrap();
         assert_eq!(pdi, unmarshaled);
+    }
+
+    #[test]
+    fn test_pdi_with_three_gpp_interface_type() {
+        let interface_type = ThreeGppInterfaceTypeIe::new(ThreeGppInterfaceType::N3);
+        let pdi = PdiBuilder::uplink_access()
+            .three_gpp_interface_type(interface_type)
+            .build()
+            .unwrap();
+
+        let unmarshaled = Pdi::unmarshal(&pdi.marshal()).unwrap();
+        assert_eq!(unmarshaled.three_gpp_interface_type, Some(interface_type));
     }
 
     #[test]

--- a/src/ie/recovery_time_stamp.rs
+++ b/src/ie/recovery_time_stamp.rs
@@ -4,7 +4,7 @@ use crate::ie::IeType;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 // NTP epoch (1900-01-01T00:00:00Z) is 2208988800 seconds before the Unix epoch (1970-01-01T00:00:00Z).
-const NTP_EPOCH_OFFSET: u64 = 2208988800;
+const NTP_EPOCH_OFFSET: u32 = 2_208_988_800;
 
 /// Represents a Recovery Time Stamp Information Element.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -18,15 +18,20 @@ impl RecoveryTimeStamp {
         RecoveryTimeStamp { timestamp }
     }
 
+    /// Returns the NTP seconds value carried on the wire.
+    ///
+    /// The PFCP field is an unsigned 32-bit NTP timestamp. Arithmetic intentionally wraps at
+    /// the NTP era boundary, preserving the value used as a PFCP restart token.
+    pub fn ntp_seconds(&self) -> u32 {
+        match self.timestamp.duration_since(UNIX_EPOCH) {
+            Ok(duration) => NTP_EPOCH_OFFSET.wrapping_add(duration.as_secs() as u32),
+            Err(error) => NTP_EPOCH_OFFSET.wrapping_sub(error.duration().as_secs() as u32),
+        }
+    }
+
     /// Marshals the RecoveryTimeStamp into a 4-byte array.
     pub fn marshal(&self) -> [u8; 4] {
-        let unix_timestamp = self
-            .timestamp
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_secs();
-        let ntp_timestamp = unix_timestamp + NTP_EPOCH_OFFSET;
-        (ntp_timestamp as u32).to_be_bytes()
+        self.ntp_seconds().to_be_bytes()
     }
 
     /// Converts this IE to a raw `Ie` value.
@@ -34,9 +39,7 @@ impl RecoveryTimeStamp {
         crate::ie::Ie::new(IeType::RecoveryTimeStamp, self.marshal().to_vec())
     }
 
-    /// Unmarshals a 4-byte slice into a RecoveryTimeStamp.
-    ///
-    /// Per 3GPP TS 29.244, Recovery Time Stamp requires exactly 4 bytes (NTP timestamp).
+    /// Unmarshals the four-octet NTP value at the start of a Recovery Time Stamp IE.
     pub fn unmarshal(data: &[u8]) -> Result<Self, PfcpError> {
         if data.len() < 4 {
             return Err(PfcpError::invalid_length(
@@ -46,16 +49,22 @@ impl RecoveryTimeStamp {
                 data.len(),
             ));
         }
-        let ntp_timestamp = u32::from_be_bytes(data[0..4].try_into().unwrap()) as u64;
-        if ntp_timestamp < NTP_EPOCH_OFFSET {
-            return Err(PfcpError::invalid_value(
-                "Recovery Time Stamp",
-                ntp_timestamp.to_string(),
-                "NTP timestamp is before Unix epoch",
-            ));
-        }
-        let unix_timestamp = ntp_timestamp - NTP_EPOCH_OFFSET;
-        let timestamp = UNIX_EPOCH + Duration::from_secs(unix_timestamp);
+        let ntp_timestamp = u32::from_be_bytes(data[..4].try_into().expect("length checked above"));
+        let timestamp = if ntp_timestamp >= NTP_EPOCH_OFFSET {
+            UNIX_EPOCH + Duration::from_secs(u64::from(ntp_timestamp - NTP_EPOCH_OFFSET))
+        } else {
+            UNIX_EPOCH
+                .checked_sub(Duration::from_secs(u64::from(
+                    NTP_EPOCH_OFFSET - ntp_timestamp,
+                )))
+                .ok_or_else(|| {
+                    PfcpError::invalid_value(
+                        "Recovery Time Stamp",
+                        ntp_timestamp.to_string(),
+                        "timestamp is outside the SystemTime range",
+                    )
+                })?
+        };
         Ok(RecoveryTimeStamp { timestamp })
     }
 }
@@ -98,5 +107,21 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, PfcpError::InvalidLength { .. }));
+    }
+
+    #[test]
+    fn test_recovery_time_stamp_preserves_pre_unix_ntp_value() {
+        let value = 42_u32;
+        let timestamp = RecoveryTimeStamp::unmarshal(&value.to_be_bytes()).unwrap();
+
+        assert_eq!(timestamp.ntp_seconds(), value);
+        assert_eq!(timestamp.marshal(), value.to_be_bytes());
+    }
+
+    #[test]
+    fn test_recovery_time_stamp_ignores_extension_octets() {
+        let timestamp = RecoveryTimeStamp::unmarshal(&[0, 0, 0, 42, 0xff]).unwrap();
+
+        assert_eq!(timestamp.ntp_seconds(), 42);
     }
 }

--- a/src/ie/sdf_filter.rs
+++ b/src/ie/sdf_filter.rs
@@ -3,6 +3,9 @@
 use crate::error::PfcpError;
 use crate::ie::{Ie, IeType};
 
+const FLOW_DESCRIPTION_PRESENT: u8 = 0x01;
+const HEADER_LENGTH: usize = 4;
+
 /// Represents a SDF Filter.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SdfFilter {
@@ -19,22 +22,44 @@ impl SdfFilter {
 
     /// Marshals the SDF Filter into a byte vector.
     pub fn marshal(&self) -> Vec<u8> {
-        self.flow_description.as_bytes().to_vec()
+        let description = self.flow_description.as_bytes();
+        let length = u16::try_from(description.len())
+            .expect("SDF Filter Flow Description exceeds the PFCP IE length field");
+        let mut data = Vec::with_capacity(HEADER_LENGTH + description.len());
+        data.extend_from_slice(&[FLOW_DESCRIPTION_PRESENT, 0]);
+        data.extend_from_slice(&length.to_be_bytes());
+        data.extend_from_slice(description);
+        data
     }
 
     /// Unmarshals a byte slice into a SDF Filter.
     ///
-    /// Per 3GPP TS 29.244, SDF Filter requires at least 1 byte (flow description).
+    /// Per 3GPP TS 29.244, the Flow Description is preceded by flags, a spare octet, and a
+    /// two-octet length.
     pub fn unmarshal(payload: &[u8]) -> Result<Self, PfcpError> {
-        if payload.is_empty() {
+        if payload.len() < HEADER_LENGTH {
             return Err(PfcpError::invalid_length(
                 "SDF Filter",
                 IeType::SdfFilter,
-                1,
-                0,
+                HEADER_LENGTH,
+                payload.len(),
             ));
         }
-        let flow_description = String::from_utf8(payload.to_vec()).map_err(|e| {
+        if payload[0] & FLOW_DESCRIPTION_PRESENT == 0 {
+            return Err(PfcpError::invalid_value(
+                "SDF Filter",
+                format!("flags 0x{:02x}", payload[0]),
+                "Flow Description flag must be present",
+            ));
+        }
+        let length = usize::from(u16::from_be_bytes([payload[2], payload[3]]));
+        let end = HEADER_LENGTH.checked_add(length).ok_or_else(|| {
+            PfcpError::invalid_value("SDF Filter", length.to_string(), "invalid field length")
+        })?;
+        let description = payload.get(HEADER_LENGTH..end).ok_or_else(|| {
+            PfcpError::invalid_length("SDF Filter", IeType::SdfFilter, end, payload.len())
+        })?;
+        let flow_description = String::from_utf8(description.to_vec()).map_err(|e| {
             PfcpError::encoding_error("SDF Filter", IeType::SdfFilter, e.utf8_error())
         })?;
         Ok(SdfFilter { flow_description })
@@ -59,6 +84,7 @@ mod tests {
             unmarshaled.flow_description,
             "permit in ip from any to 10.0.0.0/8"
         );
+        assert_eq!(&marshaled[..4], &[0x01, 0x00, 0x00, 0x23]);
     }
 
     #[test]
@@ -67,5 +93,11 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, PfcpError::InvalidLength { .. }));
+    }
+
+    #[test]
+    fn test_sdf_filter_rejects_missing_flow_description() {
+        let result = SdfFilter::unmarshal(&[0, 0, 0, 0]);
+        assert!(matches!(result, Err(PfcpError::InvalidValue { .. })));
     }
 }

--- a/src/ie/three_gpp_interface_type.rs
+++ b/src/ie/three_gpp_interface_type.rs
@@ -9,28 +9,55 @@ use crate::ie::{Ie, IeType};
 /// 3GPP Interface Type values
 ///
 /// Specifies the interface type in 5G network architecture as defined
-/// in 3GPP TS 29.244 Section 8.2.149.
+/// in 3GPP TS 29.244 Section 8.2.118.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum ThreeGppInterfaceType {
-    S1U = 0,                  // S1-U (4G)
-    S5S8U = 1,                // S5/S8-U (4G)
-    S4U = 2,                  // S4-U (3G/4G interworking)
-    S11U = 3,                 // S11-U (4G)
-    S12U = 4,                 // S12-U (4G)
-    Gn = 5,                   // Gn/Gp (3G)
-    S2aU = 6,                 // S2a-U (untrusted non-3GPP)
-    S2bU = 7,                 // S2b-U (trusted non-3GPP)
-    ENodeBCpFunctionGtpU = 8, // eNodeB GTP-U
-    ENodeBUpFunctionGtpU = 9, // eNodeB GTP-U UP
-    SgmbU = 10,               // SGmb-U (eMBMS)
-    N3 = 11,                  // N3 (5G - RAN to UPF)
-    N6 = 12,                  // N6 (5G - UPF to Data Network)
-    N9 = 13,                  // N9 (5G - UPF to UPF)
-    N4U = 14,                 // N4-U (5G)
-    N19 = 15,                 // N19 (5G - UPF to UPF for roaming)
+    S1U = 0,
+    S5S8U = 1,
+    S4U = 2,
+    S11U = 3,
+    S12U = 4,
+    GnGpU = 5,
+    S2aU = 6,
+    S2bU = 7,
+    ENodeBGtpUForDlDataForwarding = 8,
+    ENodeBGtpUForUlDataForwarding = 9,
+    SgwUpfGtpUForDlDataForwarding = 10,
+    N3 = 11,
+    N3TrustedNon3GppAccess = 12,
+    N3UntrustedNon3GppAccess = 13,
+    N3ForDataForwarding = 14,
+    N9 = 15,
+    Sgi = 16,
+    N6 = 17,
+    N19 = 18,
+    S8U = 19,
+    GpU = 20,
+    N9ForRoaming = 21,
+    IuU = 22,
+    N9ForDataForwarding = 23,
+    SxaU = 24,
+    SxbU = 25,
+    SxcU = 26,
+    N4U = 27,
+    SgwUpfGtpUForUlDataForwarding = 28,
+    N6MbNmb9 = 29,
+    N3Mb = 30,
+    N19Mb = 31,
 }
 
 impl ThreeGppInterfaceType {
+    // Compatibility aliases for the names exposed before the values were aligned with TS 29.244.
+    #[allow(non_upper_case_globals)]
+    pub const Gn: Self = Self::GnGpU;
+    #[allow(non_upper_case_globals)]
+    pub const ENodeBCpFunctionGtpU: Self = Self::ENodeBGtpUForDlDataForwarding;
+    #[allow(non_upper_case_globals)]
+    pub const ENodeBUpFunctionGtpU: Self = Self::ENodeBGtpUForUlDataForwarding;
+    #[allow(non_upper_case_globals)]
+    pub const SgmbU: Self = Self::SgwUpfGtpUForDlDataForwarding;
+
     /// Creates from u8 value
     pub fn from_u8(value: u8) -> Result<Self, PfcpError> {
         match value {
@@ -39,21 +66,37 @@ impl ThreeGppInterfaceType {
             2 => Ok(ThreeGppInterfaceType::S4U),
             3 => Ok(ThreeGppInterfaceType::S11U),
             4 => Ok(ThreeGppInterfaceType::S12U),
-            5 => Ok(ThreeGppInterfaceType::Gn),
+            5 => Ok(ThreeGppInterfaceType::GnGpU),
             6 => Ok(ThreeGppInterfaceType::S2aU),
             7 => Ok(ThreeGppInterfaceType::S2bU),
-            8 => Ok(ThreeGppInterfaceType::ENodeBCpFunctionGtpU),
-            9 => Ok(ThreeGppInterfaceType::ENodeBUpFunctionGtpU),
-            10 => Ok(ThreeGppInterfaceType::SgmbU),
+            8 => Ok(ThreeGppInterfaceType::ENodeBGtpUForDlDataForwarding),
+            9 => Ok(ThreeGppInterfaceType::ENodeBGtpUForUlDataForwarding),
+            10 => Ok(ThreeGppInterfaceType::SgwUpfGtpUForDlDataForwarding),
             11 => Ok(ThreeGppInterfaceType::N3),
-            12 => Ok(ThreeGppInterfaceType::N6),
-            13 => Ok(ThreeGppInterfaceType::N9),
-            14 => Ok(ThreeGppInterfaceType::N4U),
-            15 => Ok(ThreeGppInterfaceType::N19),
+            12 => Ok(ThreeGppInterfaceType::N3TrustedNon3GppAccess),
+            13 => Ok(ThreeGppInterfaceType::N3UntrustedNon3GppAccess),
+            14 => Ok(ThreeGppInterfaceType::N3ForDataForwarding),
+            15 => Ok(ThreeGppInterfaceType::N9),
+            16 => Ok(ThreeGppInterfaceType::Sgi),
+            17 => Ok(ThreeGppInterfaceType::N6),
+            18 => Ok(ThreeGppInterfaceType::N19),
+            19 => Ok(ThreeGppInterfaceType::S8U),
+            20 => Ok(ThreeGppInterfaceType::GpU),
+            21 => Ok(ThreeGppInterfaceType::N9ForRoaming),
+            22 => Ok(ThreeGppInterfaceType::IuU),
+            23 => Ok(ThreeGppInterfaceType::N9ForDataForwarding),
+            24 => Ok(ThreeGppInterfaceType::SxaU),
+            25 => Ok(ThreeGppInterfaceType::SxbU),
+            26 => Ok(ThreeGppInterfaceType::SxcU),
+            27 => Ok(ThreeGppInterfaceType::N4U),
+            28 => Ok(ThreeGppInterfaceType::SgwUpfGtpUForUlDataForwarding),
+            29 => Ok(ThreeGppInterfaceType::N6MbNmb9),
+            30 => Ok(ThreeGppInterfaceType::N3Mb),
+            31 => Ok(ThreeGppInterfaceType::N19Mb),
             _ => Err(PfcpError::invalid_value(
                 "3GPP Interface Type",
                 value.to_string(),
-                "must be 0-15",
+                "must be 0-31",
             )),
         }
     }
@@ -63,15 +106,24 @@ impl ThreeGppInterfaceType {
         self as u8
     }
 
-    /// Returns true if this is a 5G interface (N3, N6, N9, N4U, N19)
+    /// Returns true if this is a 5G interface.
     pub fn is_5g_interface(self) -> bool {
         matches!(
             self,
             ThreeGppInterfaceType::N3
+                | ThreeGppInterfaceType::N3TrustedNon3GppAccess
+                | ThreeGppInterfaceType::N3UntrustedNon3GppAccess
+                | ThreeGppInterfaceType::N3ForDataForwarding
                 | ThreeGppInterfaceType::N6
                 | ThreeGppInterfaceType::N9
                 | ThreeGppInterfaceType::N4U
                 | ThreeGppInterfaceType::N19
+                | ThreeGppInterfaceType::N9ForRoaming
+                | ThreeGppInterfaceType::N9ForDataForwarding
+                | ThreeGppInterfaceType::SgwUpfGtpUForUlDataForwarding
+                | ThreeGppInterfaceType::N6MbNmb9
+                | ThreeGppInterfaceType::N3Mb
+                | ThreeGppInterfaceType::N19Mb
         )
     }
 
@@ -84,7 +136,12 @@ impl ThreeGppInterfaceType {
                 | ThreeGppInterfaceType::S4U
                 | ThreeGppInterfaceType::S11U
                 | ThreeGppInterfaceType::S12U
-                | ThreeGppInterfaceType::SgmbU
+                | ThreeGppInterfaceType::S2aU
+                | ThreeGppInterfaceType::S2bU
+                | ThreeGppInterfaceType::ENodeBGtpUForDlDataForwarding
+                | ThreeGppInterfaceType::ENodeBGtpUForUlDataForwarding
+                | ThreeGppInterfaceType::SgwUpfGtpUForDlDataForwarding
+                | ThreeGppInterfaceType::S8U
         )
     }
 }
@@ -103,8 +160,7 @@ impl ThreeGppInterfaceTypeIe {
 
     /// Marshals the IE into bytes
     pub fn marshal(&self) -> Vec<u8> {
-        // 1 byte for interface type value + 5 spare bytes (total 6 bytes)
-        vec![self.interface_type.to_u8(), 0, 0, 0, 0, 0]
+        vec![self.interface_type.to_u8()]
     }
 
     /// Unmarshals bytes into the IE
@@ -118,7 +174,7 @@ impl ThreeGppInterfaceTypeIe {
             ));
         }
 
-        let interface_type = ThreeGppInterfaceType::from_u8(payload[0])?;
+        let interface_type = ThreeGppInterfaceType::from_u8(payload[0] & 0x3f)?;
         Ok(ThreeGppInterfaceTypeIe { interface_type })
     }
 
@@ -186,30 +242,13 @@ mod tests {
 
     #[test]
     fn test_3gpp_interface_type_all_values() {
-        let types = vec![
-            ThreeGppInterfaceType::S1U,
-            ThreeGppInterfaceType::S5S8U,
-            ThreeGppInterfaceType::S4U,
-            ThreeGppInterfaceType::S11U,
-            ThreeGppInterfaceType::S12U,
-            ThreeGppInterfaceType::Gn,
-            ThreeGppInterfaceType::S2aU,
-            ThreeGppInterfaceType::S2bU,
-            ThreeGppInterfaceType::ENodeBCpFunctionGtpU,
-            ThreeGppInterfaceType::ENodeBUpFunctionGtpU,
-            ThreeGppInterfaceType::SgmbU,
-            ThreeGppInterfaceType::N3,
-            ThreeGppInterfaceType::N6,
-            ThreeGppInterfaceType::N9,
-            ThreeGppInterfaceType::N4U,
-            ThreeGppInterfaceType::N19,
-        ];
-
-        for interface_type in types {
+        for value in 0..=31 {
+            let interface_type = ThreeGppInterfaceType::from_u8(value).unwrap();
             let ie = ThreeGppInterfaceTypeIe::new(interface_type);
             let marshaled = ie.marshal();
             let unmarshaled = ThreeGppInterfaceTypeIe::unmarshal(&marshaled).unwrap();
             assert_eq!(ie, unmarshaled);
+            assert_eq!(marshaled, [value]);
         }
     }
 

--- a/src/ie/up_function_features.rs
+++ b/src/ie/up_function_features.rs
@@ -32,7 +32,7 @@ impl UPFunctionFeatures {
     }
 
     pub fn marshal(&self) -> [u8; 2] {
-        self.bits().to_be_bytes()
+        self.bits().to_le_bytes()
     }
 
     pub fn unmarshal(data: &[u8]) -> Result<Self, crate::error::PfcpError> {
@@ -45,11 +45,19 @@ impl UPFunctionFeatures {
             ));
         }
         let bits = if data.len() == 1 {
-            u16::from_be_bytes([0, data[0]])
+            u16::from_le_bytes([data[0], 0])
         } else {
-            u16::from_be_bytes([data[0], data[1]])
+            u16::from_le_bytes([data[0], data[1]])
         };
         Ok(UPFunctionFeatures::from_bits_truncate(bits))
+    }
+
+    /// Wraps the feature bitmap in an UP Function Features IE.
+    pub fn to_ie(self) -> crate::ie::Ie {
+        crate::ie::Ie::new(
+            crate::ie::IeType::UpFunctionFeatures,
+            self.marshal().to_vec(),
+        )
     }
 }
 
@@ -64,5 +72,16 @@ mod tests {
         let marshaled = features.marshal();
         let unmarshaled = UPFunctionFeatures::unmarshal(&marshaled).unwrap();
         assert_eq!(features, unmarshaled);
+    }
+
+    #[test]
+    fn test_up_function_features_uses_pfcp_octet_order() {
+        let features = UPFunctionFeatures::FTUP | UPFunctionFeatures::EMPU;
+
+        assert_eq!(features.marshal(), [0x10, 0x01]);
+        assert_eq!(
+            UPFunctionFeatures::unmarshal(&[0x10]).unwrap(),
+            UPFunctionFeatures::FTUP
+        );
     }
 }

--- a/src/ie/update_forwarding_parameters.rs
+++ b/src/ie/update_forwarding_parameters.rs
@@ -466,7 +466,7 @@ mod tests {
 
         // Enable proxy ARP for special routing scenarios
         let params = UpdateForwardingParameters::new()
-            .with_destination_interface(DestinationInterface::new(Interface::Dn))
+            .with_destination_interface(DestinationInterface::new(Interface::SgiLanN6Lan))
             .with_network_instance(NetworkInstance::new("lan"))
             .with_proxying(Proxying::arp());
 

--- a/src/ie/update_qer.rs
+++ b/src/ie/update_qer.rs
@@ -119,7 +119,7 @@ impl UpdateQer {
 ///
 /// // Update QER with new rate limits
 /// let rate_limited_qer = UpdateQerBuilder::new(QerId::new(2))
-///     .mbr(Mbr::new(2000000, 4000000)) // 2Mbps up, 4Mbps down
+///     .mbr(Mbr::new(2000, 4000)) // 2 Mbit/s up, 4 Mbit/s down
 ///     .build()
 ///     .unwrap();
 ///
@@ -169,15 +169,15 @@ impl UpdateQerBuilder {
         self
     }
 
-    /// Sets both uplink and downlink rates with the same values for MBR.
-    pub fn rate_limit(mut self, uplink_bps: u64, downlink_bps: u64) -> Self {
-        self.mbr = Some(Mbr::new(uplink_bps, downlink_bps));
+    /// Sets both uplink and downlink MBR values in kbit/s.
+    pub fn rate_limit(mut self, uplink_kbps: u64, downlink_kbps: u64) -> Self {
+        self.mbr = Some(Mbr::new(uplink_kbps, downlink_kbps));
         self
     }
 
-    /// Sets guaranteed bit rates for both directions.
-    pub fn guaranteed_rate(mut self, uplink_bps: u64, downlink_bps: u64) -> Self {
-        self.gbr = Some(Gbr::new(uplink_bps, downlink_bps));
+    /// Sets both uplink and downlink GBR values in kbit/s.
+    pub fn guaranteed_rate(mut self, uplink_kbps: u64, downlink_kbps: u64) -> Self {
+        self.gbr = Some(Gbr::new(uplink_kbps, downlink_kbps));
         self
     }
 
@@ -261,29 +261,29 @@ mod tests {
     #[test]
     fn test_update_qer_builder_with_rate_limits() {
         let qer = UpdateQerBuilder::new(QerId::new(2))
-            .rate_limit(1000000, 2000000)
+            .rate_limit(1_000, 2_000)
             .build()
             .unwrap();
 
         assert_eq!(qer.qer_id, QerId::new(2));
         assert!(qer.mbr.is_some());
         let mbr = qer.mbr.unwrap();
-        assert_eq!(mbr.uplink, 1000000);
-        assert_eq!(mbr.downlink, 2000000);
+        assert_eq!(mbr.uplink, 1000);
+        assert_eq!(mbr.downlink, 2000);
     }
 
     #[test]
     fn test_update_qer_builder_with_guaranteed_rate() {
         let qer = UpdateQerBuilder::new(QerId::new(3))
-            .guaranteed_rate(500000, 1000000)
+            .guaranteed_rate(500, 1_000)
             .build()
             .unwrap();
 
         assert_eq!(qer.qer_id, QerId::new(3));
         assert!(qer.gbr.is_some());
         let gbr = qer.gbr.unwrap();
-        assert_eq!(gbr.uplink, 500000);
-        assert_eq!(gbr.downlink, 1000000);
+        assert_eq!(gbr.uplink, 500);
+        assert_eq!(gbr.downlink, 1000);
     }
 
     #[test]
@@ -294,8 +294,8 @@ mod tests {
                 GateStatusValue::Open,
                 GateStatusValue::Open,
             ))
-            .rate_limit(2000000, 4000000)
-            .guaranteed_rate(1000000, 2000000)
+            .rate_limit(2_000, 4_000)
+            .guaranteed_rate(1_000, 2_000)
             .build()
             .unwrap();
 
@@ -375,7 +375,7 @@ mod tests {
     #[test]
     fn test_update_qer_builder_round_trip_marshal() {
         let qer = UpdateQerBuilder::new(QerId::new(10))
-            .rate_limit(3000000, 5000000)
+            .rate_limit(3_000, 5_000)
             .gate_status(GateStatus::new(
                 GateStatusValue::Open,
                 GateStatusValue::Open,
@@ -392,8 +392,8 @@ mod tests {
     #[test]
     fn test_update_qer_builder_with_mbr_and_gbr() {
         let qer = UpdateQerBuilder::new(QerId::new(11))
-            .mbr(Mbr::new(4000000, 6000000))
-            .gbr(Gbr::new(2000000, 3000000))
+            .mbr(Mbr::new(4_000, 6_000))
+            .gbr(Gbr::new(2_000, 3_000))
             .build()
             .unwrap();
 
@@ -414,8 +414,8 @@ mod tests {
                 GateStatusValue::Closed,
                 GateStatusValue::Closed,
             ))
-            .rate_limit(1500000, 2500000)
-            .guaranteed_rate(750000, 1250000)
+            .rate_limit(1_500, 2_500)
+            .guaranteed_rate(750, 1_250)
             .build()
             .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@
 //!
 //! // Advanced FAR with network instance and validation
 //! let internet_far = CreateFar::builder(FarId::new(14))
-//!     .forward_to_network(Interface::Dn, NetworkInstance::new("internet.apn"))
+//!     .forward_to_network(Interface::SgiLanN6Lan, NetworkInstance::new("internet.apn"))
 //!     .build()
 //!     .unwrap();
 //!

--- a/src/message/session_establishment_request.rs
+++ b/src/message/session_establishment_request.rs
@@ -1260,6 +1260,7 @@ mod tests {
             sdf_filter: None,
             application_id: None,
             ethernet_packet_filter: None,
+            three_gpp_interface_type: None,
             redundant_transmission_parameters: None,
             protocol_description: None,
         };


### PR DESCRIPTION
Thanks for your work on `rs-pfcp`.

While using this crate to implement a UPF, I found several PFCP IE encoding and decoding issues. This PR fixes recovery timestamps, feature octet order, Destination Interface values, Release 18 3GPP Interface Type support, compact F-TEID CHOOSE encoding, the SDF Filter flow-description envelope, and MBR/GBR units.

Each fix has targeted regression tests and cites the relevant TS 29.244 section in its commit message.

Validated with `cargo fmt --all -- --check` and `cargo test --all-targets` (3,054 tests passed).
