### PR TITLE
fix(ie): F-TEID CH=1 encoding, IeIterator resync, lenient decode

### DIFF
--- a/examples/pcap-reader/main.rs
+++ b/examples/pcap-reader/main.rs
@@ -284,14 +284,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         println!();
                     }
                     Err(e) => {
-                        println!("Packet {packet_count}: Failed to parse PFCP message: {e}");
-                        if pfcp_data.len() >= 4 {
-                            println!(
-                                "  Raw header: {:02x} {:02x} {:02x} {:02x}",
-                                pfcp_data[0], pfcp_data[1], pfcp_data[2], pfcp_data[3]
-                            );
-                        }
+                        println!(
+                            "Packet {packet_count}: Failed to strictly parse PFCP message: {e}"
+                        );
                         println!("  Payload length: {}", pfcp_data.len());
+                        println!("  Falling back to best-effort (lossy) decode:");
+
+                        // Strict parse() rejects the whole message on a
+                        // single malformed/missing IE. describe_lossy()
+                        // never fails: it decodes the header directly and
+                        // walks whatever IEs it can, so a genuinely
+                        // malformed capture (or non-compliant peer) still
+                        // shows everything decodable instead of just an
+                        // error string and 4 raw bytes.
+                        let lossy = rs_pfcp::message::display::describe_lossy(pfcp_data);
+                        match args.format.as_str() {
+                            "json" => match serde_json::to_string_pretty(&lossy) {
+                                Ok(json) => println!("{json}"),
+                                Err(e) => println!("  Error serializing lossy decode: {e}"),
+                            },
+                            _ => match serde_yaml_ng::to_string(&lossy) {
+                                Ok(yaml) => println!("{yaml}"),
+                                Err(e) => println!("  Error serializing lossy decode: {e}"),
+                            },
+                        }
                         println!();
                     }
                 }

--- a/src/comparison/builder/compare.rs
+++ b/src/comparison/builder/compare.rs
@@ -5,51 +5,9 @@ use crate::comparison::{
     IeMismatch, MessageDiff, MismatchReason, OptionalIeMode,
 };
 use crate::error::PfcpError;
-use crate::ie::{Ie, IeType};
+use crate::ie::{is_grouped_ie, Ie, IeType};
 use crate::message::Message;
 use std::collections::{HashMap, HashSet};
-
-/// Check if an IE type is a grouped IE (contains child IEs).
-///
-/// Grouped IEs are defined per 3GPP TS 29.244 Section 8.2 as Information Elements
-/// that contain other Information Elements as their payload.
-fn is_grouped_ie(ie_type: IeType) -> bool {
-    matches!(
-        ie_type,
-        IeType::CreatePdr
-            | IeType::Pdi
-            | IeType::CreateFar
-            | IeType::ForwardingParameters
-            | IeType::DuplicatingParameters
-            | IeType::CreateUrr
-            | IeType::CreateQer
-            | IeType::CreatedPdr
-            | IeType::UpdatePdr
-            | IeType::UpdateFar
-            | IeType::UpdateForwardingParameters
-            | IeType::UpdateBarWithinSessionReportResponse
-            | IeType::UpdateUrr
-            | IeType::UpdateQer
-            | IeType::CreateBar
-            | IeType::UpdateBar
-            | IeType::LoadControlInformation
-            | IeType::OverloadControlInformation
-            | IeType::ApplicationIdsPfds
-            | IeType::PfdContext
-            | IeType::UpdateDuplicatingParameters
-            | IeType::CreateTrafficEndpoint
-            | IeType::UpdateTrafficEndpoint
-            | IeType::UsageReportWithinSessionModificationResponse
-            | IeType::UsageReportWithinSessionDeletionResponse
-            | IeType::UsageReportWithinSessionReportRequest
-            | IeType::UpdateMar
-            | IeType::UpdateTgppAccessForwardingActionInformation
-            | IeType::UpdateNonTgppAccessForwardingActionInformation
-            | IeType::UpdateSrr
-            | IeType::UpdatedPdr
-            | IeType::RedundantTransmissionForwardingParameters
-    )
-}
 
 /// Parse child IEs from a grouped IE payload.
 ///
@@ -579,31 +537,6 @@ mod tests {
     // ========================================================================
     // Deep Grouped IE Comparison Tests
     // ========================================================================
-
-    #[test]
-    fn test_is_grouped_ie() {
-        // Test that grouped IEs are correctly identified
-        assert!(is_grouped_ie(IeType::CreatePdr));
-        assert!(is_grouped_ie(IeType::CreateFar));
-        assert!(is_grouped_ie(IeType::CreateQer));
-        assert!(is_grouped_ie(IeType::CreateUrr));
-        assert!(is_grouped_ie(IeType::CreateBar));
-        assert!(is_grouped_ie(IeType::Pdi));
-        assert!(is_grouped_ie(IeType::ForwardingParameters));
-        assert!(is_grouped_ie(IeType::DuplicatingParameters));
-        assert!(is_grouped_ie(IeType::CreatedPdr));
-        assert!(is_grouped_ie(IeType::UpdatePdr));
-        assert!(is_grouped_ie(IeType::UpdateFar));
-        assert!(is_grouped_ie(IeType::UpdateQer));
-        assert!(is_grouped_ie(IeType::UpdateUrr));
-
-        // Test that non-grouped IEs are not identified as grouped
-        assert!(!is_grouped_ie(IeType::Cause));
-        assert!(!is_grouped_ie(IeType::PdrId));
-        assert!(!is_grouped_ie(IeType::FarId));
-        assert!(!is_grouped_ie(IeType::Fteid));
-        assert!(!is_grouped_ie(IeType::RecoveryTimeStamp));
-    }
 
     #[test]
     fn test_parse_child_ies_empty() {

--- a/src/ie/f_teid.rs
+++ b/src/ie/f_teid.rs
@@ -67,6 +67,11 @@ impl Fteid {
     }
 
     /// Marshals the F-TEID into a byte vector.
+    ///
+    /// Per 3GPP TS 29.244, Section 8.2.3: if the CH (CHOOSE) flag is set, the
+    /// TEID, IPv4 address, and IPv6 address fields are NOT present on the wire
+    /// (the UP function chooses them). In that case the Choose ID (if CHID is
+    /// set) immediately follows the flags octet.
     pub fn marshal(&self) -> Vec<u8> {
         let mut data = Vec::new();
         let mut flags = 0;
@@ -83,12 +88,14 @@ impl Fteid {
             flags |= 0x08; // CHID flag (bit 3)
         }
         data.push(flags);
-        data.extend_from_slice(&self.teid.0.to_be_bytes());
-        if let Some(addr) = self.ipv4_address {
-            data.extend_from_slice(&addr.octets());
-        }
-        if let Some(addr) = self.ipv6_address {
-            data.extend_from_slice(&addr.octets());
+        if !self.ch {
+            data.extend_from_slice(&self.teid.0.to_be_bytes());
+            if let Some(addr) = self.ipv4_address {
+                data.extend_from_slice(&addr.octets());
+            }
+            if let Some(addr) = self.ipv6_address {
+                data.extend_from_slice(&addr.octets());
+            }
         }
         // Only include choose_id if CHID flag is set
         if self.chid {
@@ -99,13 +106,17 @@ impl Fteid {
 
     /// Unmarshals a byte slice into an F-TEID.
     ///
-    /// Per 3GPP TS 29.244, F-TEID requires minimum 5 bytes (1 byte flags + 4 bytes TEID).
+    /// Per 3GPP TS 29.244, Section 8.2.3: the flags octet is always present.
+    /// If the CH (CHOOSE) flag is NOT set, a 4-byte TEID follows, plus an
+    /// IPv4 and/or IPv6 address per the V4/V6 flags. If CH IS set, the TEID
+    /// and address fields are entirely absent from the wire, and the Choose
+    /// ID (if CHID is set) immediately follows the flags octet.
     pub fn unmarshal(payload: &[u8]) -> Result<Self, PfcpError> {
-        if payload.len() < 5 {
+        if payload.is_empty() {
             return Err(PfcpError::invalid_length(
                 "F-TEID",
                 IeType::Fteid,
-                5,
+                1,
                 payload.len(),
             ));
         }
@@ -114,30 +125,37 @@ impl Fteid {
         let v6 = flags & 0x02 != 0;
         let ch = flags & 0x04 != 0;
         let chid = flags & 0x08 != 0;
-        let teid = u32::from_be_bytes([payload[1], payload[2], payload[3], payload[4]]);
-        let mut offset = 5;
-        let ipv4_address = if v4 && !ch {
-            // IPv4 address is present only if V4 flag is set and CHOOSE flag is NOT set
+
+        let mut offset = 1;
+        let (teid, ipv4_address, ipv6_address) = if ch {
+            // CH=1: TEID and addresses are not present on the wire.
+            (0u32, None, None)
+        } else {
             if payload.len() < offset + 4 {
                 return Err(PfcpError::invalid_length(
-                    "F-TEID IPv4",
+                    "F-TEID",
                     IeType::Fteid,
                     offset + 4,
                     payload.len(),
                 ));
             }
-            let addr = Ipv4Addr::new(
+            let teid = u32::from_be_bytes([
                 payload[offset],
                 payload[offset + 1],
                 payload[offset + 2],
                 payload[offset + 3],
-            );
+            ]);
             offset += 4;
-            Some(addr)
-        } else if v4 && ch {
-            // V4 flag set with CHOOSE flag - check if address is present
-            if payload.len() >= offset + 4 {
-                // Address is present (optional with CHOOSE)
+
+            let ipv4_address = if v4 {
+                if payload.len() < offset + 4 {
+                    return Err(PfcpError::invalid_length(
+                        "F-TEID IPv4",
+                        IeType::Fteid,
+                        offset + 4,
+                        payload.len(),
+                    ));
+                }
                 let addr = Ipv4Addr::new(
                     payload[offset],
                     payload[offset + 1],
@@ -147,41 +165,29 @@ impl Fteid {
                 offset += 4;
                 Some(addr)
             } else {
-                // No address present with CHOOSE flag
                 None
-            }
-        } else {
-            None
-        };
-        let ipv6_address = if v6 && !ch {
-            // IPv6 address is present only if V6 flag is set and CHOOSE flag is NOT set
-            if payload.len() < offset + 16 {
-                return Err(PfcpError::invalid_length(
-                    "F-TEID IPv6",
-                    IeType::Fteid,
-                    offset + 16,
-                    payload.len(),
-                ));
-            }
-            let mut octets = [0; 16];
-            octets.copy_from_slice(&payload[offset..offset + 16]);
-            offset += 16;
-            Some(Ipv6Addr::from(octets))
-        } else if v6 && ch {
-            // V6 flag set with CHOOSE flag - check if address is present
-            if payload.len() >= offset + 16 {
-                // Address is present (optional with CHOOSE)
+            };
+
+            let ipv6_address = if v6 {
+                if payload.len() < offset + 16 {
+                    return Err(PfcpError::invalid_length(
+                        "F-TEID IPv6",
+                        IeType::Fteid,
+                        offset + 16,
+                        payload.len(),
+                    ));
+                }
                 let mut octets = [0; 16];
                 octets.copy_from_slice(&payload[offset..offset + 16]);
                 offset += 16;
                 Some(Ipv6Addr::from(octets))
             } else {
-                // No address present with CHOOSE flag
                 None
-            }
-        } else {
-            None
+            };
+
+            (teid, ipv4_address, ipv6_address)
         };
+
         // Only read choose_id if CHID flag is set
         let choose_id = if chid {
             if payload.len() < offset + 1 {
@@ -532,6 +538,8 @@ mod tests {
 
     #[test]
     fn test_fteid_with_choose_flags() {
+        // Per 3GPP TS 29.244, Section 8.2.3: when CH=1, TEID and address
+        // fields are not present on the wire, even if supplied in memory.
         let fteid = Fteid::new_with_choose(
             true,
             false,
@@ -543,13 +551,15 @@ mod tests {
             0,
         );
         let marshaled = fteid.marshal();
+
+        // Only the flags octet is present: no TEID, address, or choose_id.
+        assert_eq!(marshaled.len(), 1);
+
         let unmarshaled = Fteid::unmarshal(&marshaled).unwrap();
-        assert_eq!(unmarshaled, fteid);
         assert!(unmarshaled.ch);
         assert!(!unmarshaled.chid);
-
-        // Verify marshaled data doesn't include choose_id when chid=false
-        assert_eq!(marshaled.len(), 9); // flags(1) + teid(4) + ipv4(4) = 9 bytes
+        assert_eq!(unmarshaled.teid, Teid(0));
+        assert_eq!(unmarshaled.ipv4_address, None);
     }
 
     #[test]
@@ -593,13 +603,20 @@ mod tests {
         // First byte should have all flags set: 0x01 | 0x02 | 0x04 | 0x08 = 0x0F
         assert_eq!(marshaled[0], 0x0F);
 
+        // CH=1: no TEID/address bytes on the wire — just flags(1) + choose_id(1).
+        assert_eq!(marshaled.len(), 2);
+        assert_eq!(marshaled[1], 100);
+
         let unmarshaled = Fteid::unmarshal(&marshaled).unwrap();
-        assert_eq!(unmarshaled, fteid);
         assert!(unmarshaled.v4);
         assert!(unmarshaled.v6);
         assert!(unmarshaled.ch);
         assert!(unmarshaled.chid);
         assert_eq!(unmarshaled.choose_id, 100);
+        // TEID and addresses are not on the wire when CH=1; unmarshal cannot recover them.
+        assert_eq!(unmarshaled.teid, Teid(0));
+        assert_eq!(unmarshaled.ipv4_address, None);
+        assert_eq!(unmarshaled.ipv6_address, None);
     }
 
     #[test]
@@ -630,6 +647,80 @@ mod tests {
         let result = Fteid::unmarshal(&data);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("choose ID"));
+    }
+
+    // Regression tests for 3GPP TS 29.244, Section 8.2.3: when CH=1, the
+    // TEID/address fields are absent from the wire entirely; only the flags
+    // octet and (if CHID=1) an immediately-following Choose ID are present.
+
+    #[test]
+    fn test_fteid_unmarshal_ch_only_one_byte() {
+        // CH=1, CHID=0: a genuine wire capture can be a single flags byte.
+        // V4=1, CH=1 -> flags = 0x01 | 0x04 = 0x05
+        let data = [0x05];
+        let fteid = Fteid::unmarshal(&data).unwrap();
+        assert!(fteid.v4);
+        assert!(fteid.ch);
+        assert!(!fteid.chid);
+        assert_eq!(fteid.teid, Teid(0));
+        assert_eq!(fteid.ipv4_address, None);
+        assert_eq!(fteid.ipv6_address, None);
+    }
+
+    #[test]
+    fn test_fteid_unmarshal_ch_and_chid_two_bytes() {
+        // CH=1, CHID=1: Choose ID sits immediately after the flags octet,
+        // not after a (non-existent) TEID field.
+        // V4=1, CH=1, CHID=1 -> flags = 0x01 | 0x04 | 0x08 = 0x0D
+        let data = [0x0D, 77];
+        let fteid = Fteid::unmarshal(&data).unwrap();
+        assert!(fteid.v4);
+        assert!(fteid.ch);
+        assert!(fteid.chid);
+        assert_eq!(fteid.choose_id, 77);
+        assert_eq!(fteid.teid, Teid(0));
+        assert_eq!(fteid.ipv4_address, None);
+    }
+
+    #[test]
+    fn test_fteid_unmarshal_ch_with_chid_but_truncated() {
+        // CH=1, CHID=1, but the Choose ID byte is missing — this must still
+        // be rejected (unlike CH=0, it must NOT be misread as a TEID byte).
+        let data = [0x0D]; // flags only, no choose_id
+        let result = Fteid::unmarshal(&data);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("choose ID"));
+    }
+
+    #[test]
+    fn test_fteid_unmarshal_ch_rejects_trailing_teid_sized_bytes_as_address() {
+        // CH=1 with no V4/V6 flags set: even if 4 extra bytes trail the
+        // flags octet (as they would for a legacy/CH=0 encoding), they must
+        // NOT be consumed as a TEID — CH=1 has no TEID field at all.
+        let data = [0x04, 0xDE, 0xAD, 0xBE, 0xEF]; // ch=1, no v4/v6, no chid
+        let fteid = Fteid::unmarshal(&data).unwrap();
+        assert!(fteid.ch);
+        assert_eq!(fteid.teid, Teid(0));
+        assert_eq!(fteid.ipv4_address, None);
+        assert_eq!(fteid.ipv6_address, None);
+    }
+
+    #[test]
+    fn test_fteid_marshal_ch_omits_teid_and_addresses() {
+        // Even if the in-memory struct carries a non-zero TEID and explicit
+        // addresses, marshal() must drop them from the wire when CH=1.
+        let fteid = Fteid::new_with_choose(
+            true,
+            true,
+            true, // ch = true
+            false,
+            0xDEADBEEFu32,
+            Some(Ipv4Addr::new(192, 168, 0, 1)),
+            Some(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+            0,
+        );
+        let marshaled = fteid.marshal();
+        assert_eq!(marshaled, vec![0x07]); // V4|V6|CH, nothing else
     }
 
     // Builder pattern tests
@@ -723,10 +814,16 @@ mod tests {
         assert_eq!(fteid.ipv6_address, None);
         assert_eq!(fteid.choose_id, 0);
 
-        // Test round-trip marshaling
+        // CH=1: the in-memory TEID is not marshaled onto the wire (3GPP TS
+        // 29.244, Section 8.2.3), so it cannot round-trip.
         let marshaled = fteid.marshal();
         let unmarshaled = Fteid::unmarshal(&marshaled).unwrap();
-        assert_eq!(fteid, unmarshaled);
+        assert_eq!(unmarshaled.teid, Teid(0));
+        assert_eq!(unmarshaled.v4, fteid.v4);
+        assert_eq!(unmarshaled.v6, fteid.v6);
+        assert_eq!(unmarshaled.ch, fteid.ch);
+        assert_eq!(unmarshaled.chid, fteid.chid);
+        assert_eq!(unmarshaled.choose_id, fteid.choose_id);
     }
 
     #[test]
@@ -746,10 +843,15 @@ mod tests {
         assert_eq!(fteid.ipv6_address, None);
         assert_eq!(fteid.choose_id, 0);
 
-        // Test round-trip marshaling
+        // CH=1: the in-memory TEID is not marshaled onto the wire.
         let marshaled = fteid.marshal();
         let unmarshaled = Fteid::unmarshal(&marshaled).unwrap();
-        assert_eq!(fteid, unmarshaled);
+        assert_eq!(unmarshaled.teid, Teid(0));
+        assert_eq!(unmarshaled.v4, fteid.v4);
+        assert_eq!(unmarshaled.v6, fteid.v6);
+        assert_eq!(unmarshaled.ch, fteid.ch);
+        assert_eq!(unmarshaled.chid, fteid.chid);
+        assert_eq!(unmarshaled.choose_id, fteid.choose_id);
     }
 
     #[test]
@@ -769,10 +871,15 @@ mod tests {
         assert_eq!(fteid.ipv6_address, None);
         assert_eq!(fteid.choose_id, 0);
 
-        // Test round-trip marshaling
+        // CH=1: the in-memory TEID is not marshaled onto the wire.
         let marshaled = fteid.marshal();
         let unmarshaled = Fteid::unmarshal(&marshaled).unwrap();
-        assert_eq!(fteid, unmarshaled);
+        assert_eq!(unmarshaled.teid, Teid(0));
+        assert_eq!(unmarshaled.v4, fteid.v4);
+        assert_eq!(unmarshaled.v6, fteid.v6);
+        assert_eq!(unmarshaled.ch, fteid.ch);
+        assert_eq!(unmarshaled.chid, fteid.chid);
+        assert_eq!(unmarshaled.choose_id, fteid.choose_id);
     }
 
     #[test]
@@ -793,10 +900,18 @@ mod tests {
         assert_eq!(fteid.ipv6_address, None);
         assert_eq!(fteid.choose_id, 42);
 
-        // Test round-trip marshaling
+        // CH=1: the in-memory TEID is not marshaled onto the wire, but
+        // choose_id (CHID=1) sits immediately after the flags octet.
         let marshaled = fteid.marshal();
+        assert_eq!(marshaled.len(), 2); // flags(1) + choose_id(1)
+        assert_eq!(marshaled[1], 42);
         let unmarshaled = Fteid::unmarshal(&marshaled).unwrap();
-        assert_eq!(fteid, unmarshaled);
+        assert_eq!(unmarshaled.teid, Teid(0));
+        assert_eq!(unmarshaled.v4, fteid.v4);
+        assert_eq!(unmarshaled.v6, fteid.v6);
+        assert_eq!(unmarshaled.ch, fteid.ch);
+        assert_eq!(unmarshaled.chid, fteid.chid);
+        assert_eq!(unmarshaled.choose_id, fteid.choose_id);
     }
 
     #[test]
@@ -817,10 +932,17 @@ mod tests {
         assert_eq!(fteid.ipv6_address, None);
         assert_eq!(fteid.choose_id, 100);
 
-        // Test round-trip marshaling
+        // CH=1: the in-memory TEID is not marshaled onto the wire.
         let marshaled = fteid.marshal();
+        assert_eq!(marshaled.len(), 2); // flags(1) + choose_id(1)
+        assert_eq!(marshaled[1], 100);
         let unmarshaled = Fteid::unmarshal(&marshaled).unwrap();
-        assert_eq!(fteid, unmarshaled);
+        assert_eq!(unmarshaled.teid, Teid(0));
+        assert_eq!(unmarshaled.v4, fteid.v4);
+        assert_eq!(unmarshaled.v6, fteid.v6);
+        assert_eq!(unmarshaled.ch, fteid.ch);
+        assert_eq!(unmarshaled.chid, fteid.chid);
+        assert_eq!(unmarshaled.choose_id, fteid.choose_id);
     }
 
     // Error cases for builder validation

--- a/src/ie/mod.rs
+++ b/src/ie/mod.rs
@@ -1497,6 +1497,59 @@ impl Ie {
     }
 }
 
+/// Reports whether an IE type is a grouped IE (contains child IEs as its payload).
+///
+/// Per 3GPP TS 29.244 Section 8.2, grouped IEs are Information Elements
+/// whose payload is itself a sequence of TLV-encoded child IEs, parseable
+/// via [`IeIterator`]. Used by both the comparison framework (to decide
+/// whether to deep-compare a payload's children) and the lenient display
+/// path (to decide whether to recurse into a payload or render it as a
+/// leaf value).
+///
+/// This list covers the grouped IEs used in the session-management message
+/// flows (Create/Update/Created * IEs, PDI, forwarding/duplicating
+/// parameters, usage reports, load/overload control). It is not
+/// exhaustive of every grouped IE added across later 3GPP releases;
+/// unlisted grouped IEs are rendered as opaque payloads rather than
+/// misidentified as scalar values.
+pub(crate) fn is_grouped_ie(ie_type: IeType) -> bool {
+    matches!(
+        ie_type,
+        IeType::CreatePdr
+            | IeType::Pdi
+            | IeType::CreateFar
+            | IeType::ForwardingParameters
+            | IeType::DuplicatingParameters
+            | IeType::CreateUrr
+            | IeType::CreateQer
+            | IeType::CreatedPdr
+            | IeType::UpdatePdr
+            | IeType::UpdateFar
+            | IeType::UpdateForwardingParameters
+            | IeType::UpdateBarWithinSessionReportResponse
+            | IeType::UpdateUrr
+            | IeType::UpdateQer
+            | IeType::CreateBar
+            | IeType::UpdateBar
+            | IeType::LoadControlInformation
+            | IeType::OverloadControlInformation
+            | IeType::ApplicationIdsPfds
+            | IeType::PfdContext
+            | IeType::UpdateDuplicatingParameters
+            | IeType::CreateTrafficEndpoint
+            | IeType::UpdateTrafficEndpoint
+            | IeType::UsageReportWithinSessionModificationResponse
+            | IeType::UsageReportWithinSessionDeletionResponse
+            | IeType::UsageReportWithinSessionReportRequest
+            | IeType::UpdateMar
+            | IeType::UpdateTgppAccessForwardingActionInformation
+            | IeType::UpdateNonTgppAccessForwardingActionInformation
+            | IeType::UpdateSrr
+            | IeType::UpdatedPdr
+            | IeType::RedundantTransmissionForwardingParameters
+    )
+}
+
 /// Efficiently marshals a slice of IEs into a byte vector.
 ///
 /// Pre-allocates capacity based on IE lengths to avoid reallocations.
@@ -3017,6 +3070,29 @@ mod tests {
     /// Tests for grouped IE helper functions (Phase 2)
     mod grouped_ie_helpers {
         use super::*;
+
+        #[test]
+        fn test_is_grouped_ie() {
+            assert!(is_grouped_ie(IeType::CreatePdr));
+            assert!(is_grouped_ie(IeType::CreateFar));
+            assert!(is_grouped_ie(IeType::CreateQer));
+            assert!(is_grouped_ie(IeType::CreateUrr));
+            assert!(is_grouped_ie(IeType::CreateBar));
+            assert!(is_grouped_ie(IeType::Pdi));
+            assert!(is_grouped_ie(IeType::ForwardingParameters));
+            assert!(is_grouped_ie(IeType::DuplicatingParameters));
+            assert!(is_grouped_ie(IeType::CreatedPdr));
+            assert!(is_grouped_ie(IeType::UpdatePdr));
+            assert!(is_grouped_ie(IeType::UpdateFar));
+            assert!(is_grouped_ie(IeType::UpdateQer));
+            assert!(is_grouped_ie(IeType::UpdateUrr));
+
+            assert!(!is_grouped_ie(IeType::Cause));
+            assert!(!is_grouped_ie(IeType::PdrId));
+            assert!(!is_grouped_ie(IeType::FarId));
+            assert!(!is_grouped_ie(IeType::Fteid));
+            assert!(!is_grouped_ie(IeType::RecoveryTimeStamp));
+        }
 
         #[test]
         fn test_marshal_ies_empty() {

--- a/src/ie/mod.rs
+++ b/src/ie/mod.rs
@@ -1560,15 +1560,24 @@ pub fn marshal_ies(ies: &[Ie]) -> Vec<u8> {
 ///
 /// # Errors
 ///
-/// Returns an error if:
+/// Yields an error if:
 /// - IE header is malformed
 /// - Payload is truncated (IE extends past end)
 ///
 /// # Implementation Notes
 ///
-/// This iterator automatically stops on the first error and won't continue
-/// iteration after an error is encountered. This matches the standard error
-/// handling pattern for PFCP parsing.
+/// Every strict `unmarshal()` in this crate calls `ie_result?` on the first
+/// item, so it bails out on the first error exactly as before — this
+/// iterator's resync behavior is invisible to that pattern.
+///
+/// However, the iterator itself does not stop after an error: if the 4-byte
+/// Type+Length header was readable, it uses the declared length to skip
+/// forward to the next IE and keeps yielding subsequent (possibly
+/// well-formed) IEs. This lets lenient consumers — e.g. diagnostic/display
+/// tooling that wants to show as much of a malformed message as possible —
+/// continue past a single bad IE instead of losing the rest of the buffer.
+/// Iteration only stops for good when the header itself can't be read (fewer
+/// than 4 bytes remain), since there is no declared length to resync on.
 pub struct IeIterator<'a> {
     payload: &'a [u8],
     offset: usize,
@@ -1598,15 +1607,28 @@ impl<'a> Iterator for IeIterator<'a> {
             return None;
         }
 
-        match Ie::unmarshal(&self.payload[self.offset..]) {
+        let remaining = &self.payload[self.offset..];
+        match Ie::unmarshal(remaining) {
             Ok(ie) => {
                 let ie_len = ie.len() as usize;
                 self.offset += ie_len;
                 Some(Ok(ie))
             }
             Err(e) => {
-                // Move to end to stop iteration
-                self.offset = self.payload.len();
+                if remaining.len() >= 4 {
+                    // The Type+Length header was readable even though the
+                    // IE itself is invalid (e.g. a rejected zero-length
+                    // encoding, or a declared payload longer than what's
+                    // left in the buffer). Resync using the declared
+                    // length so a single bad IE doesn't hide the rest of
+                    // the buffer from lenient consumers.
+                    let declared_length = u16::from_be_bytes([remaining[2], remaining[3]]);
+                    self.offset += 4 + declared_length as usize;
+                } else {
+                    // Header itself is truncated — there's no declared
+                    // length to resync on, so stop iteration.
+                    self.offset = self.payload.len();
+                }
                 Some(Err(e))
             }
         }
@@ -3154,6 +3176,67 @@ mod tests {
 
             assert_eq!(count, 1, "Should parse one valid IE");
             assert!(error_found, "Should encounter error on truncated IE");
+        }
+
+        #[test]
+        fn test_ie_iterator_resyncs_past_rejected_zero_length_ie() {
+            // A rejected zero-length IE (header readable, but content
+            // invalid) should not hide a well-formed IE that follows it.
+            let mut payload = Vec::new();
+            payload.extend_from_slice(&(IeType::FarId as u16).to_be_bytes());
+            payload.extend_from_slice(&0u16.to_be_bytes()); // length = 0 (rejected)
+
+            let valid_ie = Ie::new(IeType::PdrId, vec![0x00, 0x2a]);
+            payload.extend_from_slice(&valid_ie.marshal());
+
+            let results: Vec<_> = IeIterator::new(&payload).collect();
+            assert_eq!(results.len(), 2);
+            assert!(results[0].is_err(), "zero-length FAR ID must be rejected");
+            let ie = results[1].as_ref().unwrap();
+            assert_eq!(ie.ie_type, IeType::PdrId);
+            assert_eq!(ie.payload, vec![0x00, 0x2a]);
+        }
+
+        #[test]
+        fn test_ie_iterator_resync_stops_cleanly_when_declared_length_exceeds_buffer() {
+            // Header is readable, but the declared length claims more bytes
+            // than actually remain. Resyncing by the declared length lands
+            // past the end of the buffer, which must end iteration cleanly
+            // (no panic, no infinite loop) rather than yielding bogus IEs.
+            let mut payload = Vec::new();
+            payload.extend_from_slice(&(IeType::FarId as u16).to_be_bytes());
+            payload.extend_from_slice(&100u16.to_be_bytes()); // claims 100 bytes
+            payload.extend_from_slice(&[0x01, 0x02, 0x03]); // but only 3 remain
+
+            let results: Vec<_> = IeIterator::new(&payload).collect();
+            assert_eq!(results.len(), 1);
+            assert!(results[0].is_err());
+        }
+
+        #[test]
+        fn test_ie_iterator_strict_question_mark_consumers_unaffected_by_resync() {
+            // Resync is invisible to the standard `ie_result?` pattern used
+            // by every strict unmarshal() in this crate: it still bails on
+            // the very first error and never sees the resynced IEs after it.
+            fn parse_ies(payload: &[u8]) -> Result<Vec<IeType>, PfcpError> {
+                let mut types = vec![];
+                for ie_result in IeIterator::new(payload) {
+                    let ie = ie_result?;
+                    types.push(ie.ie_type);
+                }
+                Ok(types)
+            }
+
+            let mut payload = Vec::new();
+            payload.extend_from_slice(&(IeType::FarId as u16).to_be_bytes());
+            payload.extend_from_slice(&0u16.to_be_bytes()); // rejected zero-length
+            payload.extend_from_slice(&Ie::new(IeType::PdrId, vec![0x00, 0x2a]).marshal());
+
+            let result = parse_ies(&payload);
+            assert!(
+                result.is_err(),
+                "strict consumer must still bail immediately"
+            );
         }
 
         #[test]

--- a/src/ie/pdi.rs
+++ b/src/ie/pdi.rs
@@ -514,8 +514,10 @@ mod tests {
     #[test]
     fn test_pdi_builder_comprehensive() {
         let source_interface = SourceInterface::new(SourceInterfaceValue::Access);
+        // CH=1 (choose_ipv4): per 3GPP TS 29.244 Section 8.2.3, TEID is not
+        // present on the wire, so it must be 0 to round-trip through marshal.
         let fteid = FteidBuilder::new()
-            .teid(0x87654321)
+            .teid(0)
             .choose_ipv4()
             .choose_id(42)
             .build()
@@ -631,11 +633,9 @@ mod tests {
 
     #[test]
     fn test_pdi_builder_uplink_with_f_teid() {
-        let fteid = FteidBuilder::new()
-            .teid(0xAABBCCDD)
-            .choose_ipv6()
-            .build()
-            .unwrap();
+        // CH=1 (choose_ipv6): TEID is not present on the wire, so it must be
+        // 0 to round-trip through marshal.
+        let fteid = FteidBuilder::new().teid(0).choose_ipv6().build().unwrap();
 
         let pdi = PdiBuilder::uplink_access()
             .f_teid(fteid.clone())

--- a/src/message/display.rs
+++ b/src/message/display.rs
@@ -3,7 +3,8 @@
 //! Converts PFCP messages to YAML and JSON formats for debugging and logging.
 //! IE order in the output matches the binary message (wire format).
 
-use crate::ie::{Ie, IeType};
+use crate::ie::{is_grouped_ie, Ie, IeIterator, IeType};
+use crate::message::header::Header;
 use crate::message::Message;
 use serde_json::{json, Map, Value};
 
@@ -79,6 +80,74 @@ fn message_to_value(msg: &dyn Message) -> Value {
 }
 
 // ============================================================================
+// Layer 2b: Lenient (best-effort) decode for diagnostic display
+// ============================================================================
+
+/// Decodes a raw PFCP message leniently for diagnostic display.
+///
+/// `rs_pfcp::message::parse()` is strict by design: a missing mandatory IE
+/// or a malformed top-level IE fails the whole message, which is the right
+/// behavior for code that builds or validates messages to actually send.
+/// But it means a diagnostic tool (e.g. `pcap-reader`) gets nothing to show
+/// for a message that is mostly fine but trips one of those checks.
+///
+/// This function never fails. It decodes only the fixed header via
+/// [`Header::unmarshal`] (the one part with no fallback — without it there
+/// are no reliable byte boundaries at all) and then walks the IE tree via
+/// [`ie_to_value`], which — same as the strict display path — recurses into
+/// grouped IEs and resyncs past a single malformed IE at any nesting level
+/// instead of aborting the whole walk.
+///
+/// Intended as a fallback for display/inspection tooling when strict
+/// `message::parse()` fails — not a substitute for it. It does not perform
+/// mandatory-IE or semantic validation.
+pub fn describe_lossy(data: &[u8]) -> Value {
+    let mut map = Map::new();
+
+    let header = match Header::unmarshal(data) {
+        Ok(header) => header,
+        Err(e) => {
+            map.insert("_error".into(), json!(format!("{e}")));
+            add_fallback_payload(&mut map, data);
+            return Value::Object(map);
+        }
+    };
+
+    map.insert(
+        "message_type".into(),
+        json!(format!("{:?}", header.message_type)),
+    );
+    map.insert("version".into(), json!(header.version));
+    map.insert("sequence".into(), json!(*header.sequence_number));
+    if header.has_seid {
+        map.insert("seid".into(), json!(format!("0x{:016x}", header.seid.0)));
+    }
+
+    let body = &data[(header.len() as usize).min(data.len())..];
+    let ie_array: Vec<Value> = IeIterator::new(body).map(ie_result_to_value).collect();
+    if !ie_array.is_empty() {
+        map.insert("information_elements".into(), Value::Array(ie_array));
+    }
+
+    Value::Object(map)
+}
+
+/// Converts one [`IeIterator`] item to a `Value`, whether it decoded
+/// successfully or not. Used both by [`describe_lossy`]'s top-level walk and
+/// by [`ie_to_value`]'s grouped-IE fallback, so a single malformed IE never
+/// hides its well-formed siblings at any nesting level.
+fn ie_result_to_value(result: Result<Ie, crate::error::PfcpError>) -> Value {
+    match result {
+        Ok(ie) => ie_to_value(&ie),
+        Err(e) => {
+            let mut obj = Map::new();
+            obj.insert("_error".into(), json!(format!("{e}")));
+            Value::Object(obj)
+        }
+    }
+}
+
+// ============================================================================
 // Layer 1: IE → Value
 // ============================================================================
 
@@ -90,6 +159,13 @@ enum IeDisplayResult {
 }
 
 /// Convert a single IE to a JSON value.
+///
+/// If there's no rich per-field decoder for this IE type (or it fails), a
+/// grouped IE (per [`is_grouped_ie`]) is rendered as a recursive tree of its
+/// children via [`IeIterator`] rather than an opaque hex dump — so a single
+/// malformed child (or a grouped type with no dedicated decoder yet) still
+/// exposes whatever structure could be decoded. True scalar IEs, which have
+/// no further structure to recurse into, fall back to a raw payload dump.
 fn ie_to_value(ie: &Ie) -> Value {
     let type_name = format!("{:?}", ie.ie_type);
 
@@ -109,7 +185,14 @@ fn ie_to_value(ie: &Ie) -> Value {
             let mut obj = Map::new();
             obj.insert("type".into(), json!(type_name));
             obj.insert("length".into(), json!(ie.len()));
-            add_fallback_payload(&mut obj, &ie.payload);
+            if is_grouped_ie(ie.ie_type) {
+                let children: Vec<Value> = IeIterator::new(&ie.payload)
+                    .map(ie_result_to_value)
+                    .collect();
+                obj.insert("children".into(), Value::Array(children));
+            } else {
+                add_fallback_payload(&mut obj, &ie.payload);
+            }
             Value::Object(obj)
         }
     }
@@ -739,8 +822,18 @@ mod tests {
     use crate::message::heartbeat_response::HeartbeatResponseBuilder;
     use crate::message::session_establishment_request::SessionEstablishmentRequestBuilder;
     use crate::message::session_establishment_response::SessionEstablishmentResponseBuilder;
+    use crate::message::MsgType;
     use std::net::{Ipv4Addr, Ipv6Addr};
     use std::time::SystemTime;
+
+    /// Builds the raw bytes of a rejected zero-length IE (header readable,
+    /// content invalid — `FarId` is not on the zero-length allowlist).
+    fn rejected_zero_length_ie_bytes() -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(IeType::FarId as u16).to_be_bytes());
+        bytes.extend_from_slice(&0u16.to_be_bytes());
+        bytes
+    }
 
     fn create_heartbeat_request() -> Box<dyn Message> {
         let recovery_ts = RecoveryTimeStamp::new(SystemTime::UNIX_EPOCH);
@@ -1135,5 +1228,99 @@ mod tests {
         );
         assert_eq!(json_parsed.get("sequence"), yaml_as_json.get("sequence"));
         assert_eq!(json_parsed.get("version"), yaml_as_json.get("version"));
+    }
+
+    // ========================================================================
+    // Lenient (best-effort) decode tests
+    // ========================================================================
+
+    #[test]
+    fn test_ie_to_value_grouped_ie_without_rich_decoder_recurses_into_children() {
+        // CreateQer is grouped but has no dedicated rich decoder — it must
+        // no longer collapse to an opaque hex dump.
+        let child = Ie::new(IeType::PdrId, vec![0x00, 0x01]);
+        let grouped = Ie::new(IeType::CreateQer, child.marshal());
+
+        let value = ie_to_value(&grouped);
+
+        assert_eq!(value["type"], "CreateQer");
+        assert!(value.get("payload_hex").is_none());
+        let children = value["children"].as_array().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0]["type"], "PdrId");
+    }
+
+    #[test]
+    fn test_ie_to_value_grouped_ie_resyncs_past_malformed_child() {
+        let mut payload = rejected_zero_length_ie_bytes();
+        payload.extend_from_slice(&Ie::new(IeType::PdrId, vec![0x00, 0x2a]).marshal());
+        let grouped = Ie::new(IeType::CreateQer, payload);
+
+        let value = ie_to_value(&grouped);
+        let children = value["children"].as_array().unwrap();
+
+        assert_eq!(
+            children.len(),
+            2,
+            "malformed child must not hide its sibling"
+        );
+        assert!(children[0].get("_error").is_some());
+        assert_eq!(children[1]["type"], "PdrId");
+    }
+
+    #[test]
+    fn test_describe_lossy_recovers_past_top_level_malformed_ie() {
+        // A message-level equivalent of the grouped-IE case above: a
+        // rejected zero-length IE at the top level, followed by a
+        // perfectly valid RecoveryTimeStamp IE.
+        let mut data = Header::new(MsgType::HeartbeatRequest, false, 0u64, 42u32).marshal();
+        data.extend_from_slice(&rejected_zero_length_ie_bytes());
+        let recovery_ts = crate::ie::recovery_time_stamp::RecoveryTimeStamp::new(
+            std::time::SystemTime::UNIX_EPOCH,
+        );
+        data.extend_from_slice(
+            &Ie::new(IeType::RecoveryTimeStamp, recovery_ts.marshal().to_vec()).marshal(),
+        );
+
+        // Confirm the premise: strict parsing really does fail on this data.
+        assert!(crate::message::parse(&data).is_err());
+
+        let value = describe_lossy(&data);
+        assert_eq!(value["message_type"], "HeartbeatRequest");
+        assert_eq!(value["sequence"], 42);
+
+        let ies = value["information_elements"].as_array().unwrap();
+        assert_eq!(
+            ies.len(),
+            2,
+            "the valid IE after the bad one must still show up"
+        );
+        assert!(ies[0].get("_error").is_some());
+        assert_eq!(ies[1]["type"], "RecoveryTimeStamp");
+    }
+
+    #[test]
+    fn test_describe_lossy_valid_message_has_no_errors() {
+        let request = create_heartbeat_request();
+        let data = request.marshal();
+
+        let value = describe_lossy(&data);
+        assert_eq!(value["message_type"], "HeartbeatRequest");
+        assert_eq!(value["sequence"], 12345);
+        assert!(value.get("_error").is_none());
+
+        let ies = value["information_elements"].as_array().unwrap();
+        assert!(ies.iter().all(|ie| ie.get("_error").is_none()));
+    }
+
+    #[test]
+    fn test_describe_lossy_header_too_short_reports_error_without_panicking() {
+        for data in [&[][..], &[0x21][..], &[0x21, 0x32, 0x00][..]] {
+            let value = describe_lossy(data);
+            assert!(
+                value.get("_error").is_some(),
+                "expected an error for header bytes: {data:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Three independent fixes, currently local-only, being opened as a PR for CI/review before merging:

- fix(ie): F-TEID CH=1 must omit TEID and address fields per 3GPP TS 29.244
- fix(ie): make IeIterator resync past a single malformed IE
- feat(display): add lenient decode path for malformed PFCP messages

Note: the F-TEID commit overlaps with #60 (contributor found the same CH=1 bug independently). Plan is to merge #60 first, then rebase this branch and reconcile the two f_teid.rs changes.