### PR TITLE
feat(fuzz): add roundtrip_ie + roundtrip_message targets; wire up scheduled CI (#67 Phase 3)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,69 @@
+name: Fuzz
+
+# Scheduled, time-boxed fuzzing per fuzz/README.md — not continuous fuzzing
+# on every push. Each target gets its own time-boxed run so one flaky/slow
+# target can't starve the others, and a crash on one target still reports
+# individually with its own minimized artifact.
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+    inputs:
+      seconds_per_target:
+        description: 'Seconds to fuzz each target for'
+        required: false
+        default: '180'
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - unmarshal_message
+          - unmarshal_ie
+          - describe_lossy
+          - roundtrip_ie
+          - roundtrip_message
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Install nightly Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache cargo-fuzz
+        uses: actions/cache@v6
+        with:
+          path: ~/.cargo/bin/cargo-fuzz
+          key: cargo-fuzz-${{ runner.os }}
+
+      - name: Install cargo-fuzz
+        run: command -v cargo-fuzz || cargo install cargo-fuzz
+
+      - name: Cache fuzz build artifacts
+        uses: actions/cache@v6
+        with:
+          path: fuzz/target
+          key: fuzz-target-${{ matrix.target }}-${{ hashFiles('fuzz/Cargo.lock') }}
+          restore-keys: fuzz-target-${{ matrix.target }}-
+
+      - name: Fuzz ${{ matrix.target }}
+        run: |
+          cargo +nightly fuzz run ${{ matrix.target }} -- \
+            -max_total_time=${{ github.event.inputs.seconds_per_target || '180' }}
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crash-${{ matrix.target }}
+          path: fuzz/artifacts/${{ matrix.target }}/
+          if-no-files-found: ignore

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -57,6 +57,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "bitflags"
@@ -164,6 +167,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -338,6 +352,7 @@ dependencies = [
 name = "rs-pfcp-fuzz"
 version = "0.0.0"
 dependencies = [
+ "arbitrary",
  "libfuzzer-sys",
  "pcap-file",
  "rs-pfcp",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,6 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 pcap-file = "2.0"
+arbitrary = { version = "1", features = ["derive"] }
 
 [dependencies.rs-pfcp]
 path = ".."
@@ -31,6 +32,20 @@ bench = false
 [[bin]]
 name = "describe_lossy"
 path = "fuzz_targets/describe_lossy.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "roundtrip_ie"
+path = "fuzz_targets/roundtrip_ie.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "roundtrip_message"
+path = "fuzz_targets/roundtrip_message.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -39,9 +39,27 @@ testing or structural assertions needed for these targets.
   without a hand-built dispatch table. **This target found a real bug on
   its first run** — see "Found so far" below.
 
-Planned next (see #67): a structural round-trip target using
-`arbitrary`-generated `Message`/`Ie` values, once these three have had
-more fuzzing time to shake out further easy bugs.
+- **`roundtrip_ie`** — Phase 3: uses [`arbitrary`](https://docs.rs/arbitrary)
+  to derive a structured `(raw_type, enterprise_id, payload)` input straight
+  from the fuzzer's byte buffer (not raw wire bytes — coverage-guided
+  mutation explores this struct's fields directly). Unlike `unmarshal_ie`,
+  this checks a stronger property than "doesn't panic": a freshly marshaled
+  `Ie` must always round-trip losslessly back through `Ie::unmarshal()`. A
+  mismatch here means the generic TLV container layer itself is lossy or
+  asymmetric, independent of any IE's own domain-level decoder.
+
+- **`roundtrip_message`** — Phase 3: the same idea one layer up. An
+  `arbitrary` header + bag of IEs is fed through `message::parse()`; most
+  combinations fail a mandatory-IE check and that's expected, not asserted.
+  What *is* asserted: once bytes parse into a message at all,
+  `marshal(parse(bytes))` must be a stable fixed point from then on — the
+  first parse is allowed to canonicalize IE order, but re-marshaling and
+  re-parsing after that must never change the bytes again or start failing.
+
+Both `arbitrary`-based targets take structured input rather than raw wire
+bytes, so the pcap-derived corpus in "Seeding the corpus" below doesn't
+apply to them — no seed corpus is provided; libFuzzer's coverage-guided
+mutation builds one from scratch.
 
 ## Found so far
 
@@ -96,15 +114,24 @@ regardless. Re-run `seed_corpus` any time the pcap fixtures change.
 
 ## Running
 
-Pick one of the three targets above (`unmarshal_message`, `unmarshal_ie`,
-`describe_lossy`):
+Pick one of the five targets above (`unmarshal_message`, `unmarshal_ie`,
+`describe_lossy`, `roundtrip_ie`, `roundtrip_message`):
 
 ```bash
-cargo +nightly fuzz run describe_lossy                       # run until interrupted
-cargo +nightly fuzz run describe_lossy -- -max_total_time=120  # time-boxed (used in CI)
+cargo +nightly fuzz run describe_lossy                         # run until interrupted
+cargo +nightly fuzz run describe_lossy -- -max_total_time=180  # time-boxed (used in CI)
 
 cargo +nightly fuzz build   # build all targets without running any of them
 ```
+
+## CI
+
+`.github/workflows/fuzz.yml` runs all five targets, 180s each, on a nightly
+schedule plus manual `workflow_dispatch` (with a `seconds_per_target`
+override) — deliberately not on every push or PR, per the "Status" note
+below on scope. Each target is its own matrix job so one crash or one slow
+target doesn't block the others; a failure uploads the minimized crash
+input as a build artifact for the "Triaging a crash" workflow below.
 
 ## Triaging a crash
 
@@ -134,8 +161,12 @@ cargo +nightly fuzz tmin <target> fuzz/artifacts/<target>/<crash-file>
 
 ## Status
 
-Phase 1 (all three targets above + corpus tool + local smoke runs) is done,
-and already found and fixed one real bug (see "Found so far"). CI wiring (a
-scheduled, time-boxed job rather than continuous fuzzing) and the
-`arbitrary`-based round-trip target are tracked as follow-ups in #67, not
-yet set up.
+Phase 1 (`unmarshal_message`, `unmarshal_ie`, `describe_lossy` + corpus
+tool) and Phase 3 (`roundtrip_ie`, `roundtrip_message`) are both done —
+five targets total, all with clean local smoke runs (tens of millions of
+executions with no new crashes beyond the one already fixed; see "Found so
+far"). CI wiring (`.github/workflows/fuzz.yml`, scheduled + manual, not
+continuous) is done too.
+
+Remaining, tracked in #67: nothing currently planned beyond letting these
+targets accumulate fuzzing time and triaging whatever CI turns up.

--- a/fuzz/fuzz_targets/roundtrip_ie.rs
+++ b/fuzz/fuzz_targets/roundtrip_ie.rs
@@ -1,0 +1,72 @@
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use rs_pfcp::ie::{Ie, IeType, VENDOR_SPECIFIC_IE_TYPE_MASK};
+
+// Phase 3 of the fuzzing effort tracked in #67: unlike unmarshal_ie (which
+// only checks that arbitrary bytes never panic), this target checks a
+// stronger property — that a freshly marshaled `Ie` always round-trips
+// losslessly back through `Ie::unmarshal()`. A mismatch here means the
+// generic TLV container layer (type/length/enterprise-id framing) is lossy
+// or asymmetric for some input, independent of any specific IE's own
+// domain-level decoder.
+//
+// `arbitrary` derives the input shape below straight from the fuzzer's raw
+// byte buffer, so libFuzzer's coverage-guided mutation is exploring this
+// struct's fields directly rather than raw wire bytes — no seed corpus is
+// provided for this target (see fuzz/README.md).
+#[derive(Debug, Arbitrary)]
+struct FuzzIe {
+    raw_type: u16,
+    enterprise_id: u16,
+    payload: Vec<u8>,
+}
+
+fuzz_target!(|input: FuzzIe| {
+    // Cap payload size so a single run can't blow the time/memory budget.
+    if input.payload.len() > 4096 {
+        return;
+    }
+
+    let vendor_specific = input.raw_type & VENDOR_SPECIFIC_IE_TYPE_MASK != 0;
+    let ie = if vendor_specific {
+        // Guaranteed Ok: the only failure mode is a raw_type without the
+        // vendor bit set, which we've already excluded above.
+        Ie::new_vendor_specific(input.raw_type, input.enterprise_id, input.payload.clone())
+            .expect("raw_type has the vendor bit set by construction")
+    } else {
+        let ie_type = IeType::from(input.raw_type);
+        if ie_type == IeType::Unknown {
+            // Use new_unknown() rather than new() here so raw_type is
+            // preserved on the wire — new() collapses every unknown type to
+            // the same placeholder, which would make this target blind to
+            // raw_type diversity in the "unknown, non-vendor" range.
+            // Guaranteed Ok: ie_type == Unknown and non-vendor, exactly
+            // what new_unknown() requires.
+            Ie::new_unknown(input.raw_type, input.payload.clone())
+                .expect("non-vendor unknown raw_type by construction")
+        } else {
+            Ie::new(ie_type, input.payload.clone())
+        }
+    };
+
+    let bytes = ie.marshal();
+    match Ie::unmarshal(&bytes) {
+        Ok(parsed) => assert_eq!(
+            parsed, ie,
+            "round trip changed a freshly-marshaled IE: {bytes:02x?}"
+        ),
+        Err(e) => {
+            // The only case Ie::unmarshal legitimately rejects a
+            // syntactically well-formed frame it just emitted is the
+            // zero-length DoS allowlist check (see Ie::allows_zero_length
+            // and CLAUDE.md "Zero-Length IE Validation"). Anything else
+            // means marshal() produced bytes its own unmarshal() can't read
+            // back.
+            assert!(
+                input.payload.is_empty(),
+                "unmarshal rejected a freshly-marshaled non-empty IE: {e:?} ({bytes:02x?})"
+            );
+        }
+    }
+});

--- a/fuzz/fuzz_targets/roundtrip_message.rs
+++ b/fuzz/fuzz_targets/roundtrip_message.rs
@@ -1,0 +1,87 @@
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use rs_pfcp::ie::{marshal_ies, Ie, IeType};
+use rs_pfcp::message::header::Header;
+use rs_pfcp::message::{self, MsgType};
+
+// Phase 3 of the fuzzing effort tracked in #67: a structural round-trip
+// target covering the message layer, complementing the IE-level one in
+// roundtrip_ie.rs.
+//
+// A raw header + arbitrary bag of IEs is not expected to parse cleanly most
+// of the time (real messages have mandatory-IE requirements this soup
+// mostly won't satisfy) — that's fine and not asserted. What *is* asserted
+// is the invariant that matters: once bytes DO parse into a message,
+// marshal(parse(bytes)) must be a stable fixed point. The first parse of
+// non-canonical input (e.g. IEs in an order no builder would produce) is
+// allowed to reorder them into canonical form on marshal, so bytes1 is
+// never compared directly — but from the second parse onward, re-marshaling
+// must never change the bytes again, and re-parsing must never start
+// failing. Either would mean marshal() silently produced lossy or
+// unparseable output for a message this crate itself just emitted.
+//
+// `arbitrary` derives the input shape below straight from the fuzzer's raw
+// byte buffer, so libFuzzer's coverage-guided mutation is exploring this
+// struct's fields directly rather than raw wire bytes — no seed corpus is
+// provided for this target (see fuzz/README.md).
+#[derive(Debug, Arbitrary)]
+struct FuzzIe {
+    raw_type: u16,
+    payload: Vec<u8>,
+}
+
+#[derive(Debug, Arbitrary)]
+struct FuzzMessage {
+    msg_type: u8,
+    has_seid: bool,
+    seid: u64,
+    sequence_number: u32,
+    ies: Vec<FuzzIe>,
+}
+
+fuzz_target!(|input: FuzzMessage| {
+    // Cap the IE soup so a single run can't blow the time/memory budget.
+    if input.ies.len() > 32 || input.ies.iter().any(|f| f.payload.len() > 1024) {
+        return;
+    }
+
+    let ies: Vec<Ie> = input
+        .ies
+        .into_iter()
+        // Clear the vendor bit: Ie::new() requires an explicit Enterprise ID
+        // for vendor-specific types (see roundtrip_ie.rs) and that footgun
+        // is already covered there — this target's job is message-layer
+        // structure, not re-litigating IE construction edge cases.
+        .map(|f| Ie::new(IeType::from(f.raw_type & 0x7fff), f.payload))
+        .collect();
+
+    let mut header = Header::new(
+        MsgType::from(input.msg_type),
+        input.has_seid,
+        input.seid,
+        input.sequence_number,
+    );
+    let ie_bytes = marshal_ies(&ies);
+    header.length = (header.len() - 4) + ie_bytes.len() as u16;
+
+    let mut bytes1 = header.marshal();
+    bytes1.extend_from_slice(&ie_bytes);
+
+    let Ok(m1) = message::parse(&bytes1) else {
+        return; // most random IE soup fails a mandatory-IE check — expected
+    };
+
+    let bytes2 = m1.marshal();
+    let m2 = message::parse(&bytes2).unwrap_or_else(|e| {
+        panic!(
+            "marshal() of a successfully parsed message produced bytes that \
+             fail to re-parse: {e:?}\nbytes: {bytes2:02x?}"
+        )
+    });
+    let bytes3 = m2.marshal();
+    assert_eq!(
+        bytes2, bytes3,
+        "marshal(parse(bytes)) is not a stable fixed point\nbytes2: {bytes2:02x?}\nbytes3: {bytes3:02x?}"
+    );
+});


### PR DESCRIPTION
## Summary
Continues the fuzz harness work from #75 — Phase 3 of #67.

**Two new targets**, built on [`arbitrary`](https://docs.rs/arbitrary) instead of raw bytes, checking a stronger property than Phase 1's "doesn't panic":

- **`roundtrip_ie`** — a freshly marshaled `Ie` must always round-trip losslessly back through `Ie::unmarshal()`. Catches asymmetry in the generic TLV container layer itself, independent of any IE's own domain decoder.
- **`roundtrip_message`** — once arbitrary bytes parse into a message at all, `marshal(parse(bytes))` must be a stable fixed point from then on. Catches `marshal()` silently producing lossy or unparseable output for a message the crate itself just emitted.

Both take structured `arbitrary`-derived input rather than raw wire bytes, so the pcap-seeded corpus doesn't apply to them — documented in `fuzz/README.md`.

**CI wiring**: `.github/workflows/fuzz.yml` runs all five targets (the three from #75 plus these two), 180s each, on a nightly schedule + manual `workflow_dispatch` — matrixed per-target so one crash/slow target doesn't block the others, with crash artifacts uploaded on failure. Deliberately scheduled/manual only, not on every push or PR, per the scope this was tracked under in #67.

## Verification
- Local smoke runs: 5.16M execs/45s + ~11M more execs/120s (`roundtrip_ie`), 1.52M execs/60s (`roundtrip_message`) — all clean, no crashes.
- `cargo fmt`, `cargo clippy -D warnings`, `cargo test` clean on both the main crate and `fuzz/`.
- New deps (`arbitrary`, `derive_arbitrary`) are plain `MIT OR Apache-2.0` — no new dependency-review license drift beyond what #75 already fixed.

## Next
Nothing currently planned beyond letting these five targets accumulate CI fuzzing time and triaging whatever turns up (see `fuzz/README.md` "Status").

🤖 Generated with [Claude Code](https://claude.com/claude-code)