### PR TITLE
docs(architecture): document real fuzz-testing usage, resolving remaining #67 work

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -325,8 +325,9 @@ The library strictly follows 3GPP TS 29.244 Release 18:
 - Protocol-level rejection of attack vectors
 - Bounded parsing (no infinite loops)
 - Resource limits enforced
-- Comprehensive round-trip and edge-case testing (fuzzing is not yet part of the suite —
-  see [Testing Strategy](testing-strategy.md#6-fuzz-testing))
+- Comprehensive round-trip and edge-case testing, plus `cargo-fuzz` targets on the
+  marshal/unmarshal boundary — see
+  [Testing Strategy](testing-strategy.md#6-fuzz-testing)
 
 ### See Also
 
@@ -347,7 +348,9 @@ The library strictly follows 3GPP TS 29.244 Release 18:
 1. **Unit Tests**: Individual IE and message tests
 2. **Integration Tests**: Full message workflows
 3. **Compliance Tests**: 3GPP TS 29.244 verification
-4. **Property Tests / Fuzzing**: Not yet implemented — see
+4. **Fuzz Tests**: `cargo-fuzz` targets on the marshal/unmarshal boundary — see
+   [Testing Strategy](testing-strategy.md#6-fuzz-testing)
+5. **Property Tests**: Not yet implemented (`proptest`/`quickcheck`) — see
    [Testing Strategy](testing-strategy.md#5-property-based-tests)
 
 ## Extension Points

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -355,11 +355,15 @@ fn test_security_dos_prevention() {
 
 ### Fuzzing Strategy
 
-Planned fuzzing with `cargo-fuzz`:
-- Random message generation
-- Mutated valid messages
-- Edge case exploration
-- Crash detection
+Implemented (tracked in [#67](https://github.com/xandlom/rs-pfcp/issues/67)) via
+`cargo-fuzz` — see [Testing Strategy → Fuzz Testing](testing-strategy.md#6-fuzz-testing)
+and [`fuzz/README.md`](../../fuzz/README.md) for the full setup and target list:
+- Random message and IE generation (`unmarshal_message`, `unmarshal_ie`)
+- Deep per-IE-type decode coverage via the display path (`describe_lossy`)
+- Round-trip/lossless-encoding properties, not just crash-freedom
+  (`roundtrip_ie`, `roundtrip_message`)
+- Crash detection, wired into CI on a nightly schedule with automatic
+  crash-artifact upload
 
 ## Security Audit Trail
 
@@ -372,6 +376,7 @@ Planned fuzzing with `cargo-fuzz`:
 | Issue | Version | Severity | Status |
 |-------|---------|----------|--------|
 | Zero-length IE DoS | v0.1.1 | HIGH | ✅ Fixed |
+| `FqCsid::unmarshal` subtract-with-overflow panic on truncated FQDN-type input | Unreleased (post-v0.5.0) | MEDIUM | ✅ Fixed (found by `describe_lossy` fuzz target, see `fuzz/README.md`) |
 
 ### Disclosure Policy
 
@@ -429,4 +434,4 @@ When adding new IEs or messages:
 **Security Version**: 0.3.0
 **Last Security Audit**: 2025-01-08
 **Next Planned Audit**: TBD
-**Fuzzing Status**: Planned
+**Fuzzing Status**: Implemented (5 `cargo-fuzz` targets, nightly CI — see [#67](https://github.com/xandlom/rs-pfcp/issues/67))

--- a/docs/architecture/testing-strategy.md
+++ b/docs/architecture/testing-strategy.md
@@ -391,14 +391,38 @@ mod property_tests {
 
 ### 6. Fuzz Testing
 
-**Status: Not yet implemented.** No `fuzz/` directory or `cargo-fuzz` setup exists in the
-repository today — this section documents the pattern the project would use if/when it's
-added.
+**Status: Implemented.** A `fuzz/` directory with a `cargo-fuzz` (libFuzzer) setup exists
+in the repository, tracked under [#67](https://github.com/xandlom/rs-pfcp/issues/67). See
+[`fuzz/README.md`](../../fuzz/README.md) for the full workflow (setup, corpus seeding,
+running, CI, and crash-triage procedure) — this section gives the high-level shape.
 
-Discover vulnerabilities through randomized input:
+Five targets discover vulnerabilities through randomized input, split across two
+strategies:
+
+**Crash oracles** (input: raw wire bytes; the oracle is the project's own stated
+invariant from `CLAUDE.md` — *"NO panics on invalid input — always return
+`Result<T, PfcpError>`"* — so a returned `Err` is a pass, a panic or hang is a bug):
+
+- `unmarshal_message` — fuzzes `rs_pfcp::message::parse()`, the top-level dispatch
+  across all 25 message types.
+- `unmarshal_ie` — fuzzes `Ie::unmarshal()`, the generic TLV-framing layer underneath
+  every IE (does not reach the 354 per-IE-type decoders, which are separate functions).
+- `describe_lossy` — fuzzes `message::display::describe_lossy()`, the best-effort
+  YAML/JSON path `pcap-reader` uses on real captured traffic (see #69); its internal
+  dispatch reaches deep per-IE-type decode logic across nearly all `IeType` variants.
+  Found a real bug on its first run (subtract-with-overflow panic in
+  `FqCsid::unmarshal`, fixed — see `fuzz/README.md` → "Found so far").
+
+**Round-trip properties** (input: `arbitrary`-derived structured values, not raw wire
+bytes — checks a stronger property than crash-freedom):
+
+- `roundtrip_ie` — a freshly marshaled `Ie` must always round-trip losslessly back
+  through `Ie::unmarshal()`.
+- `roundtrip_message` — once arbitrary bytes parse into a message at all,
+  `marshal(parse(bytes))` must be a stable fixed point from then on.
 
 ```rust
-// fuzz/fuzz_targets/unmarshal.rs
+// fuzz/fuzz_targets/unmarshal_message.rs (crash-oracle style, simplified)
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use rs_pfcp::message::parse;
@@ -408,13 +432,18 @@ fuzz_target!(|data: &[u8]| {
     let _ = parse(data);
 });
 
-// Run with: cargo fuzz run unmarshal
+// Run with: cargo +nightly fuzz run unmarshal_message
 ```
+
+**CI**: `.github/workflows/fuzz.yml` runs all five targets, 180s each, on a nightly
+schedule plus manual `workflow_dispatch` — matrixed per target so one crash or slow
+target doesn't block the others, with crash artifacts uploaded on failure.
 
 **Fuzz Testing Goals:**
 - Discover crashes, panics, infinite loops
 - Find buffer overflows, underflows
 - Verify memory safety
+- Verify lossless round-tripping of the TLV container and message layers
 - Test with millions of random inputs
 
 ## Test Organization
@@ -435,14 +464,15 @@ rs-pfcp/
 │   ├── session_establishment_integration.rs
 │   ├── fixture_semantic_check.rs
 │   └── ie_iteration_tests.rs
-└── benches/                     # Criterion.rs performance benchmarks
-    ├── message_operations.rs
-    ├── ie_operations.rs
-    ├── ie_performance.rs
-    └── comparison_operations.rs
+├── benches/                     # Criterion.rs performance benchmarks
+│   ├── message_operations.rs
+│   ├── ie_operations.rs
+│   ├── ie_performance.rs
+│   └── comparison_operations.rs
+└── fuzz/                         # cargo-fuzz targets (see Fuzz Testing above)
+    ├── fuzz_targets/
+    └── README.md
 ```
-
-(No `fuzz/` directory exists yet — see [Fuzz Testing](#6-fuzz-testing) above.)
 
 ### Naming Conventions
 


### PR DESCRIPTION
## Summary

Fixes #67. The fuzz harness itself (5 `cargo-fuzz` targets, seeded corpus, nightly CI) was already implemented across PRs #75/#76, but three docs never caught up and still described it as not-yet-implemented/planned:

- **`docs/architecture/testing-strategy.md`** — §6 said *"Status: Not yet implemented"* with a stale example target and a file-structure diagram that omitted `fuzz/` entirely. This was the specific doc-update step #67's own "Suggested approach" called for and the one piece of that issue left undone.
- **`docs/architecture/security.md`** — "Fuzzing Strategy: Planned fuzzing..." and "Fuzzing Status: Planned" at the bottom. Also added the `FqCsid` subtract-with-overflow panic (found by the `describe_lossy` fuzz target, already fixed) to the "Fixed Security Issues" audit trail — that table exists precisely to record findings like this.
- **`docs/architecture/overview.md`** — conflated "fuzzing" with the separate, still-genuinely-unimplemented property-based testing (`proptest`/`quickcheck`) under one "not yet implemented" bullet. Split them so the still-real property-testing gap doesn't get lost now that fuzzing is done.

No code changes.

## Testing

Docs-only change. Pre-commit hook's `cargo fmt`/`clippy`/`cargo check` all pass (no Rust source touched, so the test suite step was skipped by the hook itself). Manually verified all Markdown anchor links (`#6-fuzz-testing`, `#5-property-based-tests`) still resolve to their section headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)